### PR TITLE
Fix bug where helm home differed between client configuration and init

### DIFF
--- a/helm/deploy.go
+++ b/helm/deploy.go
@@ -88,6 +88,9 @@ func Deploy(
 	err = RunHelm(
 		kubectlOptions,
 		"init",
+		// helm home
+		"--home",
+		helmHome,
 		// Use Secrets instead of ConfigMap to track metadata
 		"--override",
 		"spec.template.spec.containers[0].command={/tiller,--storage=secret}",


### PR DESCRIPTION
This is another bug I found during integration testing of https://github.com/gruntwork-io/kubergrunt/pull/14 in `terraform-kubernetes-helm`. Now that we are passing in `helmHome` to `Deploy` as part of client configuration, the `helm init` call should point to that `helmHome` directory so that it initializes it correctly.