### PR TITLE
[WIP] Shift GKE Auth Plugin Import to `client.go`

### DIFF
--- a/kubectl/client.go
+++ b/kubectl/client.go
@@ -3,6 +3,10 @@ package kubectl
 import (
 	"k8s.io/client-go/kubernetes"
 
+	// The following line loads the gcp plugin which is required to authenticate against GKE clusters.
+	// See: https://github.com/kubernetes/client-go/issues/242
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+
 	"github.com/gruntwork-io/kubergrunt/logging"
 )
 

--- a/kubectl/node.go
+++ b/kubectl/node.go
@@ -10,10 +10,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
-	// The following line loads the gcp plugin which is required to authenticate against GKE clusters.
-	// See: https://github.com/kubernetes/client-go/issues/242
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-
 	"github.com/gruntwork-io/kubergrunt/logging"
 )
 


### PR DESCRIPTION
This PR shifts the GKE auth plugin import as per Yori's comment: https://github.com/gruntwork-io/kubergrunt/pull/25#discussion_r254768738