### PR TITLE
RDD for TLS cert management

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ The `tls` subcommand of `kubergrunt` is used to manage TLS certificate key pairs
 #### gen
 
 This subcommand will generate new TLS certificate key pairs based on the provided configuration arguments. Once the
-certificate are generated, they will be stored on your targetted Kubernetes cluster as
+certificates are generated, they will be stored on your targeted Kubernetes cluster as
 [Secrets](https://kubernetes.io/docs/concepts/configuration/secret/). This supports features such as:
 
 - Generating a new CA key pair and storing the generated key pair in your Kubernetes cluster.


### PR DESCRIPTION
This is the RDD for a new command `tls gencert`. This command is a generic TLS management tool that uses Kubernetes `Secrets` as its secret manager.

The specific use case this fulfills is [managing TLS certs for kiam](https://github.com/uswitch/kiam/blob/master/docs/TLS.md). However, it appears the pattern kiam uses is generic, and thus it is possible this has other use cases.

NOTE: Since most of the backend is implemented in the `tls` module of `kubergrunt` already, I will be diving into the implementation right away, but would love CLI design feedback despite that.