### PR TITLE
Support passing in tls subject info as json

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"crypto/x509/pkix"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -26,13 +28,17 @@ const (
 )
 
 var (
+	tlsSubjectJsonFlag = cli.StringFlag{
+		Name:  "tls-subject-json",
+		Usage: "Provide the TLS subject info as json. You can specify the common name (common_name), org (org), org unit (org_unit), city (city), state (state), and country (country) fields.",
+	}
 	tlsCommonNameFlag = cli.StringFlag{
 		Name:  "tls-common-name",
-		Usage: "(Required) The name that will go into the CN (CommonName) field of the identifier.",
+		Usage: "(Required) The name that will go into the CN (CommonName) field of the identifier. Can be omitted if the information is provided in --tls-subject-json.",
 	}
 	tlsOrgFlag = cli.StringFlag{
 		Name:  "tls-org",
-		Usage: "(Required) The name of the company that is generating this cert.",
+		Usage: "(Required) The name of the company that is generating this cert. Can be omitted if the information is provided in --tls-subject-json.",
 	}
 	tlsOrgUnitFlag = cli.StringFlag{
 		Name:  "tls-org-unit",
@@ -50,6 +56,16 @@ var (
 		Name:  "tls-country",
 		Usage: "The country where --tls-org is located.",
 	}
+	tlsSubjectInfoFlags = TLSFlags{
+		SubjectInfoJsonFlagName: tlsSubjectJsonFlag.Name,
+		CommonNameFlagName:      tlsCommonNameFlag.Name,
+		OrgFlagName:             tlsOrgFlag.Name,
+		OrgUnitFlagName:         tlsOrgUnitFlag.Name,
+		CityFlagName:            tlsCityFlag.Name,
+		StateFlagName:           tlsStateFlag.Name,
+		CountryFlagName:         tlsCountryFlag.Name,
+	}
+
 	tlsValidityFlag = cli.IntFlag{
 		Name:  "tls-validity",
 		Value: 3650,
@@ -82,6 +98,116 @@ var (
 		),
 	}
 )
+
+type TLSSubjectInfo struct {
+	CommonName string `json:"common_name"`
+	Org        string `json:"org"`
+	OrgUnit    string `json:"org_unit"`
+	City       string `json:"city"`
+	State      string `json:"state"`
+	Country    string `json:"country"`
+}
+
+type TLSFlags struct {
+	SubjectInfoJsonFlagName string
+	CommonNameFlagName      string
+	OrgFlagName             string
+	OrgUnitFlagName         string
+	CityFlagName            string
+	StateFlagName           string
+	CountryFlagName         string
+}
+
+// parseOrCreateTLSSubjectInfo will parse out the TLS subject json into a TLSSubjectInfo struct. If the string is empty,
+// this will create an empty struct that can be filled in based on the CLI args.
+func parseOrCreateTLSSubjectInfo(jsonString string) (TLSSubjectInfo, error) {
+	var subjectInfo TLSSubjectInfo
+	if jsonString != "" {
+		err := json.Unmarshal([]byte(jsonString), &subjectInfo)
+		if err != nil {
+			return subjectInfo, errors.WithStackTrace(err)
+		}
+	}
+	return subjectInfo, nil
+}
+
+// parseTLSFlagsToPkixName takes the CLI args related to setting up the Distinguished Name identifier of the TLS
+// certificate and converts them to the pkix.Name struct.
+func parseTLSFlagsToPkixName(cliContext *cli.Context, tlsFlags TLSFlags) (pkix.Name, error) {
+	tlsSubjectInfo, err := parseOrCreateTLSSubjectInfo(cliContext.String(tlsFlags.SubjectInfoJsonFlagName))
+	if err != nil {
+		return pkix.Name{}, err
+	}
+
+	var commonName, org string
+	// The CommonName field is required, so it must be provided either in the json or via CLI args
+	if tlsSubjectInfo.CommonName == "" {
+		commonName, err = entrypoint.StringFlagRequiredE(cliContext, tlsFlags.CommonNameFlagName)
+		if err != nil {
+			return pkix.Name{}, err
+		}
+	} else {
+		commonName = cliContext.String(tlsFlags.CommonNameFlagName)
+	}
+	// Override the value if it was provided via CLI
+	if commonName != "" {
+		tlsSubjectInfo.CommonName = commonName
+	}
+
+	// Do the same for org field
+	if tlsSubjectInfo.Org == "" {
+		org, err = entrypoint.StringFlagRequiredE(cliContext, tlsFlags.OrgFlagName)
+		if err != nil {
+			return pkix.Name{}, err
+		}
+	} else {
+		org = cliContext.String(tlsFlags.OrgFlagName)
+	}
+	if org != "" {
+		tlsSubjectInfo.Org = org
+	}
+
+	// The other fields are optional
+	orgUnit := cliContext.String(tlsFlags.OrgUnitFlagName)
+	if orgUnit != "" {
+		tlsSubjectInfo.OrgUnit = orgUnit
+	}
+	city := cliContext.String(tlsFlags.CityFlagName)
+	if city != "" {
+		tlsSubjectInfo.City = city
+	}
+	state := cliContext.String(tlsFlags.StateFlagName)
+	if state != "" {
+		tlsSubjectInfo.State = state
+	}
+	country := cliContext.String(tlsFlags.CountryFlagName)
+	if country != "" {
+		tlsSubjectInfo.Country = country
+	}
+
+	return tlsSubjectInfo.DistinguishedName(), nil
+}
+
+// DistinguishedName will return the TLSSubjectInfo as a pkix.Name object.
+func (tlsSubjectInfo TLSSubjectInfo) DistinguishedName() pkix.Name {
+	distinguishedName := pkix.Name{
+		CommonName:   tlsSubjectInfo.CommonName,
+		Organization: []string{tlsSubjectInfo.Org},
+	}
+	if tlsSubjectInfo.OrgUnit != "" {
+		distinguishedName.OrganizationalUnit = []string{tlsSubjectInfo.OrgUnit}
+	}
+	if tlsSubjectInfo.City != "" {
+		distinguishedName.Locality = []string{tlsSubjectInfo.City}
+	}
+	if tlsSubjectInfo.State != "" {
+		distinguishedName.Province = []string{tlsSubjectInfo.State}
+	}
+	if tlsSubjectInfo.Country != "" {
+		distinguishedName.Country = []string{tlsSubjectInfo.Country}
+	}
+	return distinguishedName
+}
 
 // parseKubectlOptions extracts kubectl related params from CLI flags
 func parseKubectlOptions(cliContext *cli.Context) (*kubectl.KubectlOptions, error) {


### PR DESCRIPTION
This introduces a new command line argument for tls called `--tls-subject-json`. The goal of this CLI arg is to allow the user to provide the TLS subject info params (e.g `--tls-common-name`) in a JSON format.

The motivation for doing this is to simplify the terraform parsing logic here: https://github.com/gruntwork-io/terraform-kubernetes-helm/blob/master/dependencies.tf#L9 