### PR TITLE
Support terraform tls args for tls subject json

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -101,10 +101,10 @@ var (
 
 type TLSSubjectInfo struct {
 	CommonName string `json:"common_name"`
-	Org        string `json:"org"`
-	OrgUnit    string `json:"org_unit"`
-	City       string `json:"city"`
-	State      string `json:"state"`
+	Org        string `json:"org" json:"organization"`
+	OrgUnit    string `json:"org_unit" json:"organizational_unit"`
+	City       string `json:"city" json:"locality"`
+	State      string `json:"state" json:"province"`
 	Country    string `json:"country"`
 }
 


### PR DESCRIPTION
Update the json struct so that we can also accept equivalent arg names in the terraform TLS subject block: https://www.terraform.io/docs/providers/tls/r/cert_request.html#common_name