### PR TITLE
[WIP] [RDD] Local tiller management

### DIFF
--- a/HELM_GUIDE.md
+++ b/HELM_GUIDE.md
@@ -383,3 +383,33 @@ configure` will also install an environment file that you can dot source to setu
 - Enable TLS verification to ensure the Tiller instance the client is connecting to is trusted.
 - Enable TLS authentication, forwarding the downloaded TLS certificate information to the Tiller instance.
 - Set the Tiller namespace so that you don't have to pass it in.
+
+### Tillerless Helm
+
+Starting with helm 3.0.0, [Tiller will be removed from helm](https://v3.helm.sh/docs/faq/#changes-since-helm-2).
+Instead, all the functionality of Tiller will be baked into the `helm` client. This means that all the operations will
+automatically inherit the permissions of the calling identity. 
+
+This has numerous advantages:
+
+- You no longer need to worry about managing a remote server in your Kubernetes cluster that has authority to perform
+  arbitrary actions on the cluster.
+- You no longer need to manage TLS certificates to guard the client and server access.
+- You no longer need to distribute the permissions across multiple Tiller instances, which distributes the source of
+  truth of deployments.
+
+However, **as of June 16th, 2019, Helm v3 is still in alpha mode** and is not available for production use.
+
+In the meantime, `kubergrunt` can help simulate tillerless helm using the `local-tiller` command. Instead of running
+Tiller in the cluster, `local-tiller` starts an instance of the Tiller server locally on the operator's machine. By
+starting the server locally, you can pass through the credentials of the operator securely to the Tiller instance.
+Additionally, the Tiller instance will be locked down to `localhost`, so that it is only accessible on the operator's
+machine. This means that:
+
+- You no longer need to manage TLS certificates because all the communication is local.
+- You no longer need to manage `ServiceAccounts` for Tiller because it inherits the credentials on the machine.
+- You no longer need multiple Tiller instances in different `Namespace`s. All the local Tiller instances can manage the
+  state in the same `Namespace`.
+
+You can learn more about the advantages of local Tiller in this blog post by @rimusz, one of the creators of Helm,
+[Tillerless Helm v2](https://rimusz.net/tillerless-helm).

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The following commands are available as part of `kubergrunt`:
     * [token](#token)
     * [deploy](#deploy)
 1. [helm](#helm)
+    * [local-tiller](#local-tiller)
     * [deploy](#helm-deploy)
     * [wait-for-tiller](#wait-for-tiller)
     * [undeploy](#undeploy)
@@ -223,6 +224,43 @@ If you are not familiar with Helm, be sure to check out [our guide](/HELM_GUIDE.
 
 **Note**: The `helm` subcommand requires the `helm` client to be installed on the operators' machine. Refer to the
 [official docs](https://docs.helm.sh/) for instructions on installing the client.
+
+
+#### local-tiller
+
+This subcommand will manage Tiller (the Helm Server) locally. Using a local Tiller instance allows helm to inherit the
+caller's Kubernetes RBAC role when deploying the chart resources.
+
+To start Tiller, pass in the `--start` option:
+
+```
+kubergrunt helm local-tiller --start
+```
+
+This command will start the Tiller server locally in the background. Upon completion, the command will output the port
+where Tiller is running, which you can use to configure your helm client. Note that this command will not attempt to
+start another instance of the server if it is already running.
+
+You can also have the command output the Tiller access information as JSON, by providing the `--output json` option:
+
+```
+kubergrunt helm local-tiller --start --output json
+```
+
+This allows you to use this command as a data source in Terraform. Checkout the [tillerless-helm
+terraform example](examples/tillerless-helm) for an example of how to use the command in Terraform with the `helm`
+provider.
+
+To stop the server, you can use the `--stop` option:
+
+```
+kubergrunt helm local-tiller --stop
+```
+
+Similar commands:
+
+- [helm-tiller](https://github.com/rimusz/helm-tiller) is a plugin for the helm client that will seamlessly start Tiller
+  locally before any command is run.
 
 
 #### (helm) deploy

--- a/cmd/helm.go
+++ b/cmd/helm.go
@@ -27,6 +27,10 @@ const (
 	RbacGroupFlag               = "rbac-group"
 	RbacUserFlag                = "rbac-user"
 	RbacServiceAccountFlag      = "rbac-service-account"
+
+	localTillerStartFlagName  = "start"
+	localTillerStopFlagName   = "stop"
+	localTillerOutputFlagName = "output"
 )
 
 var (
@@ -55,6 +59,11 @@ var (
 		Value: DefaultTillerVersion,
 		Usage: "The version of the container image to use when deploying tiller.",
 	}
+	localTillerVersionFlag = cli.StringFlag{
+		Name:  "version",
+		Value: DefaultTillerVersion,
+		Usage: "The version of tiller to run locally.",
+	}
 
 	// Configurations for the wait-for-tiller command
 	tillerDeploymentNameFlag = cli.StringFlag{
@@ -81,6 +90,20 @@ var (
 		Name:  "sleep-between-retries",
 		Value: 1 * time.Second,
 		Usage: "The amount of time to sleep inbetween each check attempt. Accepted as a duration (5s, 10m, 1h).",
+	}
+
+	// Configurations for the local-tiller command
+	localTillerStartFlag = cli.BoolFlag{
+		Name:  localTillerStartFlagName,
+		Usage: "Start Tiller (the Helm Server) locally in the background.",
+	}
+	localTillerStopFlag = cli.BoolFlag{
+		Name:  localTillerStopFlagName,
+		Usage: "Stop locally running Tiller (the Helm Server), if it has been started using kubergrunt.",
+	}
+	localTillerOutputFlag = cli.StringFlag{
+		Name:  localTillerOutputFlagName,
+		Usage: "Format to use for displaying information about the locally running Tiller server. Supports either 'text' or 'json'.",
 	}
 
 	// Configurations for how to authenticate with the Kubernetes cluster.
@@ -220,6 +243,25 @@ func SetupHelmCommand() cli.Command {
 		Usage:       "Helper commands to configure Helm.",
 		Description: "Helper commands to configure Helm, including manging TLS certificates and setting up operator machines to authenticate with Tiller.",
 		Subcommands: cli.Commands{
+			cli.Command{
+				Name:        "local-tiller",
+				Usage:       "Manage Tiller (the Helm Server) locally.",
+				Description: `Manage an instance of Tiller (the Helm Server) locally in the background, so that it can inherit the credentials of the local machine.`,
+				Action:      localHelmServer,
+				Flags: []cli.Flag{
+					localTillerVersionFlag,
+					localTillerStartFlag,
+					localTillerStopFlag,
+					localTillerOutputFlag,
+
+					// Kubernetes authentication flags
+					helmKubectlContextNameFlag,
+					helmKubeconfigFlag,
+					helmKubectlServerFlag,
+					helmKubectlCAFlag,
+					helmKubectlTokenFlag,
+				},
+			},
 			cli.Command{
 				Name:  "deploy",
 				Usage: "Install and setup a best practice Helm Server.",
@@ -397,6 +439,11 @@ You can configure the timeout settings using the --timeout and --sleep-between-r
 			},
 		},
 	}
+}
+
+// localHelmServer is the action function for helm local-tiller command.
+func localHelmServer(cliContext *cli.Context) error {
+	return fmt.Errorf("Not Implemented")
 }
 
 // deployHelmServer is the action function for helm deploy command.


### PR DESCRIPTION
Inspired by https://github.com/rimusz/helm-tiller and https://rimusz.net/tillerless-helm.

This is a proposal for a function in kubergrunt that optimizes the functionality of the `helm-tiller` plugin in the context of terraform. Specifically:

- Create a command that will start a local tiller server that can be used as a data source.
- This data source will provide the inputs for the `helm` provider.
- Create a command that can stop the local tiller server. This can be used as a clean up function in `terragrunt` in the after-hook.

Note that this is an alternative to using the plugin directly:

```
helm tiller run -- terraform apply
```

The advantage of embedding the tiller management into the terraform code is two fold:

- Avoid having to install both `helm` client and the `helm-tiller` plugin. This is based on the assumption that people will install `kubergrunt` for other uses.
- Avoid chaining multiple exec wrappers. For example, in EKS, to use the plugin, you will have to do:

```
aws-vault exec dev -- helm tiller run tiller_namespace -- terraform apply
```