### PR TITLE
Fix bug where tls subject info did not allow the second name for the keys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,13 +5,13 @@ defaults: &defaults
   environment:
     GRUNTWORK_INSTALLER_VERSION: v0.0.21
     TERRATEST_LOG_PARSER_VERSION: v0.13.13
-    MODULE_CI_VERSION: v0.13.12
+    MODULE_CI_VERSION: v0.14.1
     TERRAFORM_VERSION: NONE
     TERRAGRUNT_VERSION: NONE
     PACKER_VERSION: NONE
     GOLANG_VERSION: 1.11.2
     KUBECONFIG: /home/circleci/.kube/config
-    HELM_VERSION: v2.14.0  
+    HELM_VERSION: v2.14.0
 
 
 install_helm_client: &install_helm_client

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseTLSSubjectInfoJsonOrgOrgUnit(t *testing.T) {
+	t.Parallel()
+	subjectInfo, err := parseOrCreateTLSSubjectInfo(`{"org": "Gruntwork", "org_unit": "Eng"}`)
+	assert.NoError(t, err)
+	assert.Equal(t, subjectInfo.Org, "Gruntwork")
+	assert.Equal(t, subjectInfo.OrgUnit, "Eng")
+}
+
+func TestParseTLSSubjectInfoJsonOrganizationOrganizationalUnit(t *testing.T) {
+	t.Parallel()
+	subjectInfo, err := parseOrCreateTLSSubjectInfo(`{"organization": "Gruntwork", "organizational_unit": "Eng"}`)
+	assert.NoError(t, err)
+	assert.Equal(t, subjectInfo.Org, "Gruntwork")
+	assert.Equal(t, subjectInfo.OrgUnit, "Eng")
+}


### PR DESCRIPTION
## Problem

When I first started working on `kubergrunt`, I used the encoding for the TLS subject that matched what we had in [vault tls cert generation module](https://github.com/hashicorp/terraform-aws-vault/tree/master/modules/private-tls-cert). For example, the TLS cert org is specified by the key `org` in the json representation.

However, later on I realized that the TLS provider for terraform uses a different encoding (see the [subject block description in the cert_request resource docs](https://www.terraform.io/docs/providers/tls/r/cert_request.html#common_name)). For example, in this encoding, the cert org is specified by the key `organization`.

For flexibility, I wanted `kubergrunt` to handle both names, and did that by providing both as `json` names to the struct. However, this doesn't work.

## Solution

After some experimentation, I learned that you can't do this directly using the stdlib json parser and json tags. Instead, you need to decode both into different fields, and then manually reconcile the correct one, so I did exactly that here.