### PR TITLE
Add KUBECONFIG environment variable to kubeconfig flag

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -676,12 +676,12 @@
   version = "v1.2.2"
 
 [[projects]]
-  digest = "1:b24d38b282bacf9791408a080f606370efa3d364e4b5fd9ba0f7b87786d3b679"
+  digest = "1:ca4df663ad76879ad38dbd736493679cbb1aa596c6d479fd9fc5e959e5ceb4fb"
   name = "github.com/urfave/cli"
   packages = ["."]
   pruneopts = "UT"
-  revision = "cfb38830724cc34fedffe9a2a29fb54fa9169cd1"
-  version = "v1.20.0"
+  revision = "e6cf83ec39f6e1158ced1927d4ed14578fda8edb"
+  version = "v1.21.0"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -46,7 +46,7 @@
 
 [[constraint]]
   name = "github.com/urfave/cli"
-  version = "1.20.0"
+  version = "1.21.0"
 
 [[constraint]]
   name = "github.com/kubernetes-sigs/aws-iam-authenticator"

--- a/cmd/eks.go
+++ b/cmd/eks.go
@@ -29,8 +29,9 @@ var (
 		Usage: "The name to use for the config context that is set up to authenticate with the EKS cluster. Defaults to the cluster ARN.",
 	}
 	eksKubeconfigFlag = cli.StringFlag{
-		Name:  KubeconfigFlagName,
-		Usage: "The path to the kubectl config file to setup. Defaults to ~/.kube/config",
+		Name:   KubeconfigFlagName,
+		Usage:  "The path to the kubectl config file to use to authenticate with Kubernetes. (default: \"~/.kube/config\")",
+		EnvVar: "KUBECONFIG",
 	}
 	eksKubectlServerFlag = cli.StringFlag{
 		Name:  KubectlServerFlagName,

--- a/cmd/helm.go
+++ b/cmd/helm.go
@@ -91,8 +91,9 @@ var (
 		Usage: "The kubectl config context to use for authenticating with the Kubernetes cluster.",
 	}
 	helmKubeconfigFlag = cli.StringFlag{
-		Name:  KubeconfigFlagName,
-		Usage: "The path to the kubectl config file to use to authenticate with Kubernetes. (default: \"~/.kube/config\")",
+		Name:   KubeconfigFlagName,
+		Usage:  "The path to the kubectl config file to use to authenticate with Kubernetes. (default: \"~/.kube/config\")",
+		EnvVar: "KUBECONFIG",
 	}
 	helmKubectlServerFlag = cli.StringFlag{
 		Name:  KubectlServerFlagName,

--- a/cmd/helm.go
+++ b/cmd/helm.go
@@ -92,7 +92,7 @@ var (
 	}
 	helmKubeconfigFlag = cli.StringFlag{
 		Name:   KubeconfigFlagName,
-		Usage:  "The path to the kubectl config file to use to authenticate with Kubernetes. (default: \"~/.kube/config\")",
+		Usage:  "The path to the kubectl config file to use to authenticate with Kubernetes. You can also set this using the environment variable KUBECONFIG. (default: \"~/.kube/config\")",
 		EnvVar: "KUBECONFIG",
 	}
 	helmKubectlServerFlag = cli.StringFlag{

--- a/cmd/k8s.go
+++ b/cmd/k8s.go
@@ -39,7 +39,7 @@ var (
 	}
 	k8sKubeconfigFlag = cli.StringFlag{
 		Name:   KubeconfigFlagName,
-		Usage:  "The path to the kubectl config file to use to authenticate with Kubernetes. (default: \"~/.kube/config\")",
+		Usage:  "The path to the kubectl config file to use to authenticate with Kubernetes. You can also set this using the environment variable KUBECONFIG. (default: \"~/.kube/config\")",
 		EnvVar: "KUBECONFIG",
 	}
 	k8sKubectlServerFlag = cli.StringFlag{

--- a/cmd/k8s.go
+++ b/cmd/k8s.go
@@ -38,8 +38,9 @@ var (
 		Usage: "The kubectl config context to use for authenticating with the Kubernetes cluster.",
 	}
 	k8sKubeconfigFlag = cli.StringFlag{
-		Name:  KubeconfigFlagName,
-		Usage: "The path to the kubectl config file to use to authenticate with Kubernetes. (default: \"~/.kube/config\")",
+		Name:   KubeconfigFlagName,
+		Usage:  "The path to the kubectl config file to use to authenticate with Kubernetes. (default: \"~/.kube/config\")",
+		EnvVar: "KUBECONFIG",
 	}
 	k8sKubectlServerFlag = cli.StringFlag{
 		Name:  KubectlServerFlagName,

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -41,6 +41,11 @@ func main() {
 	app := entrypoint.NewApp()
 	entrypoint.HelpTextLineWidth = 120
 
+	// Override the CLI FlagEnvHinter so it only returns the Usage text of the Flag and doesn't apend the envVar text. Original func https://github.com/urfave/cli/blob/master/flag.go#L652
+	cli.FlagEnvHinter = func(envVar, str string) string {
+		return str
+	}
+
 	app.Name = "kubergrunt"
 	app.Author = "Gruntwork <www.gruntwork.io>"
 	app.Description = "A CLI tool to help setup and manage a Kubernetes cluster."

--- a/cmd/tls.go
+++ b/cmd/tls.go
@@ -59,8 +59,9 @@ var (
 		Usage: "The name to use for the config context that is set up to authenticate with the Kubernetes cluster.",
 	}
 	tlsKubeconfigFlag = cli.StringFlag{
-		Name:  KubeconfigFlagName,
-		Usage: "The path to the kubectl config file to setup. Defaults to ~/.kube/config",
+		Name:   KubeconfigFlagName,
+		Usage:  "The path to the kubectl config file to use to authenticate with Kubernetes. (default: \"~/.kube/config\")",
+		EnvVar: "KUBECONFIG",
 	}
 	tlsKubectlServerFlag = cli.StringFlag{
 		Name:  KubectlServerFlagName,

--- a/cmd/tls.go
+++ b/cmd/tls.go
@@ -60,7 +60,7 @@ var (
 	}
 	tlsKubeconfigFlag = cli.StringFlag{
 		Name:   KubeconfigFlagName,
-		Usage:  "The path to the kubectl config file to use to authenticate with Kubernetes. (default: \"~/.kube/config\")",
+		Usage:  "The path to the kubectl config file to use to authenticate with Kubernetes. You can also set this using the environment variable KUBECONFIG. (default: \"~/.kube/config\")",
 		EnvVar: "KUBECONFIG",
 	}
 	tlsKubectlServerFlag = cli.StringFlag{


### PR DESCRIPTION
This commit adds the environment variable KUBECONFIG to the KubeconfigFlags in the eks, helm, k8s and tls packages.

Adding the EnvVar means the precedence will follow as per the [urfave/cli package](https://github.com/urfave/cli#precedence)

1. Command line flag value from user
2. Environment variable
3. Default (As specified in the function KubeConfigPathFromHomeDir)

This closes #58