### PR TITLE
Create the golang binary in seperate bin directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ __pycache__
 
 # Generic temporary files
 /tmp
+
+# Go binary directory
+bin

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ gruntwork-install --binary-name "kubergrunt" --repo "https://github.com/gruntwor
 The main package is in `cmd`. To build the binary, you can run:
 
 ```
-go build -o kubergrunt ./cmd
+go build -o bin/kubergrunt ./cmd
 ```
 
 


### PR DESCRIPTION
This patch updates the README file to create the kubergrunt binary within a bin
directory and adds the folder to gitignore to not let git track the folder.

This is just a suggestion PR which I thought while setting up the project.

Signed-off-by: Sayan Chowdhury <sayan.chowdhury2012@gmail.com>