### PR TITLE
Convenience command to retrieve OIDC Issuer thumbprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The following commands are available as part of `kubergrunt`:
     * [verify](#verify)
     * [configure](#configure)
     * [token](#token)
+    * [oidc-thumbprint](#oidc-thumbprint)
     * [deploy](#deploy)
 1. [helm](#helm)
     * [deploy](#helm-deploy)
@@ -163,6 +164,31 @@ Similar Commands:
   Terraform.
 - [`aws-iam-authenticator`](https://github.com/kubernetes-sigs/aws-iam-authenticator): This is a standalone binary that
   can be used to fetch a temporary auth token.
+
+#### oidc-thumbprint
+
+This subcommand will take the EKS OIDC Issuer URL and retrieve the root CA thumbprint. This is used to set the trust
+relation for any certificates signed by that CA for the issuer domain. This is necessary to setup the OIDC provider,
+which is used for the IAM Roles for Service Accounts feature of EKS.
+
+You can read more about the general procedure for retrieving the root CA thumbprint of an OIDC Provider in [the official
+documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html).
+
+To retrieve the thumbprint, call the command with the issuer URL:
+
+```bash
+kubergrunt eks oidc-thumbprint --issuer-url $ISSUER_URL
+```
+
+This will output the thumbprint to stdout in JSON format, with the key `ca_thumbprint`.
+
+Run `kubergrunt eks oidc-thumbprint --help` to see all the available options.
+
+Similar Commands:
+
+- You can use `openssl` to retrieve the thumbprint as described by [the official
+  documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html).
+- `eksctl` provides routines for directly configuring the OIDC provider so you don't need to retrieve the thumbprint.
 
 #### deploy
 

--- a/eks/errors.go
+++ b/eks/errors.go
@@ -124,3 +124,12 @@ type CredentialsError struct {
 func (err CredentialsError) Error() string {
 	return fmt.Sprintf("Error finding AWS credentials. Did you set the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables or configure an AWS profile? Underlying error: %v", err.UnderlyingErr)
 }
+
+// NoPeerCertificatesError is returned when we couldn't find any TLS peer certificates for the provided URL.
+type NoPeerCertificatesError struct {
+	URL string
+}
+
+func (err NoPeerCertificatesError) Error() string {
+	return fmt.Sprintf("Could not find any peer certificates for URL %s", err.URL)
+}

--- a/eks/oidc.go
+++ b/eks/oidc.go
@@ -1,0 +1,124 @@
+package eks
+
+import (
+	"crypto/sha1"
+	"crypto/tls"
+	"encoding/hex"
+	"encoding/json"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+	"path"
+
+	"github.com/gruntwork-io/gruntwork-cli/errors"
+
+	"github.com/gruntwork-io/kubergrunt/logging"
+)
+
+type Thumbprint struct {
+	Thumbprint string `json:"thumbprint"`
+}
+
+type PartialOIDCConfig struct {
+	JwksURI string `json:"jwks_uri"`
+}
+
+// GetOIDCThumbprint will retrieve the thumbprint of the root CA for the OIDC Provider identified by the issuer URL.
+// This is done by first looking up the domain where the keys are provided, and then looking up the TLS certificate
+// chain for that domain.
+func GetOIDCThumbprint(issuerURL string) (*Thumbprint, error) {
+	logger := logging.GetProjectLogger()
+	logger.Infof("Retrieving OIDC Issuer (%s) CA Thumbprint", issuerURL)
+
+	openidConfigURL, err := getOIDCConfigURL(issuerURL)
+	if err != nil {
+		logger.Errorf("Error parsing OIDC Issuer URL: %s is not a valid URL", issuerURL)
+		return nil, err
+	}
+
+	jwksURL, err := getJwksURL(openidConfigURL)
+	if err != nil {
+		logger.Errorf("Error retrieving JWKS URI from Issuer Config URL %s", openidConfigURL)
+		return nil, err
+	}
+
+	thumbprint, err := getThumbprint(jwksURL)
+	if err != nil {
+		logger.Errorf("Error retrieving root CA Thumbprint for JWKS URL %s", jwksURL)
+		return nil, err
+	}
+	logger.Infof("Retrieved OIDC Issuer (%s) CA Thumbprint: %s", issuerURL, thumbprint)
+	return &Thumbprint{Thumbprint: thumbprint}, nil
+}
+
+// getOIDCConfigURL constructs the URL where you can retrieve the OIDC Config information for a given OIDC provider.
+func getOIDCConfigURL(issuerURL string) (string, error) {
+	parsedURL, err := url.Parse(issuerURL)
+	if err != nil {
+		return "", errors.WithStackTrace(err)
+	}
+
+	parsedURL.Path = path.Join(parsedURL.Path, ".well-known", "openid-configuration")
+	openidConfigURL := parsedURL.String()
+	return openidConfigURL, nil
+}
+
+// getJwksURL returns the configured URL where the JWKS keys can be retrieved from the provider.
+func getJwksURL(openidConfigURL string) (string, error) {
+	resp, err := http.Get(openidConfigURL)
+	if err != nil {
+		return "", errors.WithStackTrace(err)
+	}
+
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", errors.WithStackTrace(err)
+	}
+
+	var partialOIDCConfig PartialOIDCConfig
+	if err := json.Unmarshal(body, &partialOIDCConfig); err != nil {
+		return "", errors.WithStackTrace(err)
+	}
+
+	return partialOIDCConfig.JwksURI, nil
+}
+
+// getThumbprint will get the root CA from TLS certificate chain for the FQDN of the JWKS URL.
+func getThumbprint(jwksURL string) (string, error) {
+	parsedURL, err := url.Parse(jwksURL)
+	if err != nil {
+		return "", errors.WithStackTrace(err)
+	}
+	hostname := parsedURL.Host
+	if parsedURL.Port() == "" {
+		hostname = net.JoinHostPort(hostname, "443")
+	}
+
+	tlsConfig := tls.Config{}
+	conn, err := tls.Dial("tcp", hostname, &tlsConfig)
+	if err != nil {
+		return "", errors.WithStackTrace(err)
+	}
+	defer conn.Close()
+
+	state := conn.ConnectionState()
+	peerCerts := state.PeerCertificates
+	numCerts := len(peerCerts)
+	if numCerts == 0 {
+		return "", errors.WithStackTrace(NoPeerCertificatesError{jwksURL})
+	}
+
+	// root CA certificate is the last one in the list
+	root := peerCerts[numCerts-1]
+	return sha1Hash(root.Raw), nil
+}
+
+// sha1Hash computes the SHA1 of the byte array and returns the hex encoding as a string.
+func sha1Hash(data []byte) string {
+	hasher := sha1.New()
+	hasher.Write(data)
+	hashed := hasher.Sum(nil)
+	return hex.EncodeToString(hashed)
+}

--- a/eks/oidc_test.go
+++ b/eks/oidc_test.go
@@ -1,0 +1,62 @@
+package eks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetOIDCConfigURL(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name      string
+		issuerURL string
+		expected  string
+	}{
+		{
+			"base",
+			"https://accounts.google.com",
+			"https://accounts.google.com/.well-known/openid-configuration",
+		},
+		{
+			"trailing-slash",
+			"https://accounts.google.com/",
+			"https://accounts.google.com/.well-known/openid-configuration",
+		},
+		{
+			"include-path",
+			"https://accounts.google.com/id/1234",
+			"https://accounts.google.com/id/1234/.well-known/openid-configuration",
+		},
+	}
+
+	for _, testCase := range testCases {
+		// Capture range variable to bring in scope within for loop to avoid it changing
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			configURL, err := getOIDCConfigURL(testCase.issuerURL)
+			assert.NoError(t, err)
+			assert.Equal(t, configURL, testCase.expected)
+		})
+	}
+}
+
+func TestGetJwksURL(t *testing.T) {
+	const configURL = "https://accounts.google.com/.well-known/openid-configuration"
+	const expected = "https://www.googleapis.com/oauth2/v3/certs"
+	jwksURL, err := getJwksURL(configURL)
+	assert.NoError(t, err)
+	assert.Equal(t, jwksURL, expected)
+}
+
+func TestGetThumbprint(t *testing.T) {
+	const jwksURL = "https://www.googleapis.com/oauth2/v3/certs"
+	const expected = "dfe2070c79e7ff36a925ffa327ffe3deecf8f9c2"
+	thumbprint, err := getThumbprint(jwksURL)
+	assert.NoError(t, err)
+	assert.Equal(t, thumbprint, expected)
+}


### PR DESCRIPTION
Currently setting up the IAM Role for Service Accounts feature in Terraform is a bit of a pain because there is no easy way to retrieve the OIDC issuer thumbprint for setting up the provider. This adds the functionality into `kubergrunt` so that it can be used as an external data source:

```
resource "aws_eks_cluster" "example" {
  # ... other configuration ...
}

data "external" "oidc_thumbprint" {
  program = ["kubergrunt", "eks", "oidc-thumbprint", "--issuer-url", aws_eks_cluster.example.identity.0.oidc.0.issuer]
}

resource "aws_iam_openid_connect_provider" "example" {
  client_id_list  = ["sts.amazonaws.com"]
  thumbprint_list = [data.external.oidc_thumbprint.result.thumbprint]
  url             = "${aws_eks_cluster.example.identity.0.oidc.0.issuer}"
}
```