### PR TITLE
Make sure to cordon all the nodes in a rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ When you call the command, it will:
    with the new launch configuration.
 1. Wait for the new nodes to be ready for Pod scheduling in Kubernetes. This includes waiting for the new nodes to be
    registered to any external load balancers managed by Kubernetes.
+1. Cordon the old instances in the ASG so that they won't schedule new Pods.
 1. Drain the pods scheduled on the old EKS workers (using the equivalent of `kubectl drain`), so that they will be
    rescheduled on the new EKS workers.
 1. Wait for all the pods to migrate off of the old EKS workers.

--- a/cmd/eks.go
+++ b/cmd/eks.go
@@ -143,9 +143,10 @@ func SetupEksCommand() cli.Command {
 
   1. Double the desired capacity of the Auto Scaling Group that powers the EKS Cluster. This will launch new EKS workers with the new launch configuration.
   2. Wait for the new nodes to be ready for Pod scheduling in Kubernetes.
-  3. Drain the pods scheduled on the old EKS workers (using the equivalent of "kubectl drain"), so that they will be rescheduled on the new EKS workers.
-  4. Wait for all the pods to migrate off of the old EKS workers.
-  5. Set the desired capacity down to the original value and remove the old EKS workers from the ASG.
+  3. Cordon the old nodes in the cluster so that they won't be able to schedule new Pods.
+  4. Drain the pods scheduled on the old EKS workers (using the equivalent of "kubectl drain"), so that they will be rescheduled on the new EKS workers.
+  5. Wait for all the pods to migrate off of the old EKS workers.
+  6. Set the desired capacity down to the original value and remove the old EKS workers from the ASG.
 
 Note that to minimize service disruption from this command, your services should setup a PodDisruptionBudget, a readiness probe that fails on container shutdown events, and implement graceful handling of SIGTERM in the container.
 

--- a/eks/asg.go
+++ b/eks/asg.go
@@ -203,6 +203,21 @@ func drainNodesInAsg(
 	return kubectl.DrainNodes(kubectlOptions, eksKubeNodeNames, drainTimeout)
 }
 
+// Make the call to cordon all the provided nodes in Kubernetes so that they won't be used to schedule new Pods.
+func cordonNodesInAsg(
+	ec2Svc *ec2.EC2,
+	kubectlOptions *kubectl.KubectlOptions,
+	asgInstanceIds []string,
+) error {
+	instances, err := instanceDetailsFromIds(ec2Svc, asgInstanceIds)
+	if err != nil {
+		return err
+	}
+	eksKubeNodeNames := kubeNodeNamesFromInstances(instances)
+
+	return kubectl.CordonNodes(kubectlOptions, eksKubeNodeNames)
+}
+
 // detachInstances will request AWS to detach the instances, removing them from the ASG. In the process, it will also
 // request to auto decrement the desired capacity.
 func detachInstances(asgSvc *autoscaling.AutoScaling, asgName string, idList []string) error {

--- a/kubectl/errors.go
+++ b/kubectl/errors.go
@@ -73,6 +73,39 @@ func NewNodeDrainErrors() NodeDrainErrors {
 	return NodeDrainErrors{[]NodeDrainError{}}
 }
 
+// NodeCordonError is returned when there is an error cordoning a node.
+type NodeCordonError struct {
+	Error  error
+	NodeID string
+}
+
+// NodeCordonErrors is returned when there are errors cordoning nodes concurrently. Each node that has an error is added
+// to the list.
+type NodeCordonErrors struct {
+	errors []NodeCordonError
+}
+
+func (err NodeCordonErrors) Error() string {
+	base := "Multiple errors caught while cordoning nodes:\n"
+	for _, subErr := range err.errors {
+		subErrMessage := fmt.Sprintf("Node %s: %s", subErr.NodeID, subErr.Error)
+		base = base + subErrMessage + "\n"
+	}
+	return base
+}
+
+func (err NodeCordonErrors) AddError(newErr NodeCordonError) {
+	err.errors = append(err.errors, newErr)
+}
+
+func (err NodeCordonErrors) IsEmpty() bool {
+	return len(err.errors) == 0
+}
+
+func NewNodeCordonErrors() NodeCordonErrors {
+	return NodeCordonErrors{[]NodeCordonError{}}
+}
+
 // LoadBalancerNotReadyError is returned when the LoadBalancer Service is unexpectedly not ready.
 type LoadBalancerNotReadyError struct {
 	serviceName string


### PR DESCRIPTION
Fixes https://github.com/gruntwork-io/kubergrunt/issues/64. Otherwise, Pods may reschedule on existing nodes and trigger thrashing during the drain procedure.

**Note**: Testing will be done in the Gruntwork IaC `terraform-aws-eks` module. A temporary integration testing release will be cut with branch that the module will reference for testing.