### PR TITLE
update to aws sdk 1.25.4

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -77,7 +77,7 @@
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:46ac2040470a18dc8130e62243b6be7d7b392aa6cfedace0c57f5781b07de4d2"
+  digest = "1:4e8c462fc3f6021f83129c819145cb3bb645bc50162c4e1e533ce42eae8a4b83"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -90,6 +90,7 @@
     "aws/credentials",
     "aws/credentials/ec2rolecreds",
     "aws/credentials/endpointcreds",
+    "aws/credentials/processcreds",
     "aws/credentials/stscreds",
     "aws/crr",
     "aws/csm",
@@ -102,6 +103,7 @@
     "internal/ini",
     "internal/s3err",
     "internal/sdkio",
+    "internal/sdkmath",
     "internal/sdkrand",
     "internal/sdkuri",
     "internal/shareddefaults",
@@ -135,10 +137,11 @@
     "service/sqs",
     "service/ssm",
     "service/sts",
+    "service/sts/stsiface",
   ]
   pruneopts = "UT"
-  revision = "89734ade0df0a4a437cbf4aa9c14e17daf37c5ac"
-  version = "v1.15.86"
+  revision = "9deb6031265e7efb2ed0c2c87cf4549ed9483554"
+  version = "v1.25.5"
 
 [[projects]]
   digest = "1:1343a2963481a305ca4d051e84bc2abd16b601ee22ed324f8d605de1adb291b0"
@@ -477,11 +480,11 @@
   version = "v1.0"
 
 [[projects]]
-  digest = "1:e22af8c7518e1eab6f2eab2b7d7558927f816262586cd6ed9f349c97a6c285c4"
+  digest = "1:bb81097a5b62634f3e9fec1014657855610c82d19b9a40c17612e32651e35dca"
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
   pruneopts = "UT"
-  revision = "0b12d6b5"
+  revision = "c2b33e84"
 
 [[projects]]
   digest = "1:3e551bbb3a7c0ab2a2bf4660e7fcad16db089fdcfbb44b0199e62838038623ea"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -30,7 +30,7 @@
 
 [[constraint]]
   name = "github.com/aws/aws-sdk-go"
-  version = "1.14.26"
+  version = "1.25.4"
 
 [[constraint]]
   name = "github.com/gruntwork-io/terratest"


### PR DESCRIPTION
- Update to AWS SDK 1.25.4 (latest version) so kubergrunt can be used in an EKS container that is assuming an IAM role as described [here](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-minimum-sdk.html)