### PR TITLE
Add DNS Names to certificate Subject Alternative Name

### DIFF
--- a/cmd/tls.go
+++ b/cmd/tls.go
@@ -49,6 +49,12 @@ var (
 		Usage: "Basename to use for the TLS certificate key pair file names when storing in the Kubernetes Secret resource. Defaults to ca when generating CA certs, and tls otherwise.",
 	}
 
+	// Flags for adding Subject Alternitive Names
+	tlsDNSNamesFlag = cli.StringSliceFlag{
+		Name:  "tls-dns-name",
+		Usage: "The subject alternitive name to add to the certificate. Pass in multiple times for multiple DNS names.",
+	}
+
 	// NOTE: Configurations for setting up the TLS certificates are defined in cmd/common.go
 
 	// Configurations for how to authenticate with the Kubernetes cluster.
@@ -115,6 +121,7 @@ Pass in a --ca-secret-name to sign the newly generated TLS key pair using the CA
 					tlsAlgorithmFlag,
 					tlsECDSACurveFlag,
 					tlsRSABitsFlag,
+					tlsDNSNamesFlag,
 
 					// Kubernetes auth flags
 					tlsKubectlContextNameFlag,
@@ -175,6 +182,7 @@ func generateTLSCertEntrypoint(cliContext *cli.Context) error {
 	} else if tlsSecretFileNameBase == "" && !genCA {
 		tlsSecretFileNameBase = "tls"
 	}
+	dnsNames := cliContext.StringSlice(tlsDNSNamesFlag.Name)
 
 	// Convert flags to structs
 	tlsSecretOptions := tls.KubernetesSecretOptions{
@@ -197,6 +205,7 @@ func generateTLSCertEntrypoint(cliContext *cli.Context) error {
 		genCA,
 		tlsSecretFileNameBase,
 		tlsOptions,
+		dnsNames,
 	)
 }
 

--- a/helm/deploy.go
+++ b/helm/deploy.go
@@ -185,6 +185,7 @@ func generateCertificateKeyPairs(tlsOptions tls.TLSOptions, tillerNamespace stri
 		true,
 		nil,
 		nil,
+		nil,
 	)
 	if err != nil {
 		logger.Errorf("Error generating CA TLS certificate key pair: %s", err)
@@ -232,6 +233,7 @@ func generateSignedCertificateKeyPair(
 		tmpStorePath,
 		"", // Tiller does not support passwords on the private key
 		false,
+		nil,
 		signingCertificate,
 		signingKey,
 	)

--- a/tls/ecdsa_cert.go
+++ b/tls/ecdsa_cert.go
@@ -31,6 +31,7 @@ func CreateECDSACertificateKeyPair(
 	signedBy *x509.Certificate,
 	signedByKey interface{}, // We don't know what format the signing key is in, so we will accept any type
 	isCA bool,
+	dnsNames []string,
 	ecdsaCurve string,
 ) (TLSECDSACertificateKeyPair, error) {
 	privateKey, publicKey, err := CreateECDSAKeyPair(ecdsaCurve)
@@ -48,6 +49,7 @@ func CreateECDSACertificateKeyPair(
 		distinguishedName,
 		signedBy,
 		isCA,
+		dnsNames,
 		publicKey,
 		signingKey,
 	)

--- a/tls/ecdsa_cert_test.go
+++ b/tls/ecdsa_cert_test.go
@@ -13,12 +13,12 @@ func TestCreateECDSACertificateKeyPairSupportsSigningCerts(t *testing.T) {
 	t.Parallel()
 
 	distinguishedName := CreateSampleDistinguishedName(t)
-	caKeyPair, err := CreateECDSACertificateKeyPair(1*time.Hour, distinguishedName, nil, nil, true, "P256")
+	caKeyPair, err := CreateECDSACertificateKeyPair(1*time.Hour, distinguishedName, nil, nil, true, nil, "P256")
 	require.NoError(t, err)
 	caCert, err := caKeyPair.Certificate()
 	require.NoError(t, err)
 
-	signedKeyPair, err := CreateECDSACertificateKeyPair(1*time.Hour, distinguishedName, caCert, caKeyPair.PrivateKey, false, "P256")
+	signedKeyPair, err := CreateECDSACertificateKeyPair(1*time.Hour, distinguishedName, caCert, caKeyPair.PrivateKey, false, nil, "P256")
 	require.NoError(t, err)
 	signedCert, err := signedKeyPair.Certificate()
 	require.NoError(t, err)
@@ -40,12 +40,12 @@ func TestCreateECDSACertificateKeyPairSupportsSigningByRSACerts(t *testing.T) {
 	t.Parallel()
 
 	distinguishedName := CreateSampleDistinguishedName(t)
-	caKeyPair, err := CreateRSACertificateKeyPair(1*time.Hour, distinguishedName, nil, nil, true, 2048)
+	caKeyPair, err := CreateRSACertificateKeyPair(1*time.Hour, distinguishedName, nil, nil, true, nil, 2048)
 	require.NoError(t, err)
 	caCert, err := caKeyPair.Certificate()
 	require.NoError(t, err)
 
-	signedKeyPair, err := CreateECDSACertificateKeyPair(1*time.Hour, distinguishedName, caCert, caKeyPair.PrivateKey, false, "P256")
+	signedKeyPair, err := CreateECDSACertificateKeyPair(1*time.Hour, distinguishedName, caCert, caKeyPair.PrivateKey, false, nil, "P256")
 	require.NoError(t, err)
 	signedCert, err := signedKeyPair.Certificate()
 	require.NoError(t, err)

--- a/tls/gencmd.go
+++ b/tls/gencmd.go
@@ -34,6 +34,7 @@ func GenerateAndStoreAsK8SSecret(
 	genCA bool,
 	filenameBase string,
 	tlsOptions TLSOptions,
+	dnsNames []string,
 ) error {
 	logger := logging.GetProjectLogger()
 	logger.Info("Generating certificate key pairs")
@@ -67,7 +68,7 @@ func GenerateAndStoreAsK8SSecret(
 			return err
 		}
 		caCertPath = caKeyPairPath.CertificatePath
-		keyPairPath, err = generateSignedTLSKeyPair(tlsPath, tlsOptions, caKeyPairPath, caKeyPairAlgorithm, filenameBase)
+		keyPairPath, err = generateSignedTLSKeyPair(tlsPath, tlsOptions, caKeyPairPath, caKeyPairAlgorithm, filenameBase, dnsNames)
 		if err != nil {
 			return err
 		}
@@ -105,6 +106,7 @@ func generateCAKeyPair(tlsPath string, tlsOptions TLSOptions, filenameBase strin
 		true,
 		nil,
 		nil,
+		nil,
 	)
 	if err == nil {
 		logger.Info("Successfully generated CA TLS certificate key pair and stored in temp workspace.")
@@ -121,6 +123,7 @@ func generateSignedTLSKeyPair(
 	caKeyPairPath CertificateKeyPairPath,
 	caKeyPairAlgorithm string,
 	filenameBase string,
+	dnsNames []string,
 ) (CertificateKeyPairPath, error) {
 	logger := logging.GetProjectLogger()
 	logger.Info("Generating signed certificate key pairs from loaded CA and storing into temporary workspace")
@@ -149,6 +152,7 @@ func generateSignedTLSKeyPair(
 		tlsPath,
 		"", // TODO: support passworded key pairs
 		false,
+		dnsNames,
 		signingCertificate,
 		signingKey,
 	)

--- a/tls/gencmd_test.go
+++ b/tls/gencmd_test.go
@@ -33,6 +33,9 @@ func TestGenerateAndStoreAsK8SSecret(t *testing.T) {
 	kubectlOptions := kubectl.GetTestKubectlOptions(t)
 	sampleTlsOptions := SampleTlsOptions(ECDSAAlgorithm)
 
+	// Setup Subject Alternitive DNS names to add to the certificate
+	var dnsNames []string = nil
+
 	// First pass: the CA options
 	caSecretName := strings.ToLower(random.UniqueId())
 	caSecretOptions := KubernetesSecretOptions{
@@ -51,6 +54,7 @@ func TestGenerateAndStoreAsK8SSecret(t *testing.T) {
 		true,
 		caFilenameBase,
 		sampleTlsOptions,
+		dnsNames,
 	)
 	require.NoError(t, err)
 
@@ -72,6 +76,7 @@ func TestGenerateAndStoreAsK8SSecret(t *testing.T) {
 		false,
 		filenameBase,
 		sampleTlsOptions,
+		dnsNames,
 	)
 	require.NoError(t, err)
 
@@ -101,6 +106,9 @@ func TestGenerateAndStoreAsK8SSecretErrorsIfCADoesNotExist(t *testing.T) {
 		Annotations: map[string]string{},
 	}
 
+	// Setup Subject Alternitive DNS names to add to the certificate
+	var dnsNames []string = nil
+
 	// Attempt to generate the TLS certificate, but verify it failed in looking up the CA certificate key pair
 	filenameBase := random.UniqueId()
 	err := GenerateAndStoreAsK8SSecret(
@@ -110,6 +118,7 @@ func TestGenerateAndStoreAsK8SSecretErrorsIfCADoesNotExist(t *testing.T) {
 		false,
 		filenameBase,
 		sampleTlsOptions,
+		dnsNames,
 	)
 	assert.Error(t, err)
 	assert.True(t, strings.Contains(err.Error(), fmt.Sprintf("secrets \"%s\" not found", secretName)))
@@ -141,6 +150,9 @@ func TestGenerateAndStoreAsK8SSecretSupportsTagging(t *testing.T) {
 		},
 	}
 
+	// Setup Subject Alternitive DNS names to add to the certificate
+	var dnsNames []string = nil
+
 	// Generate the TLS certificate and then verify it created a Kubernetes Secret with the provided label and
 	// annotation.
 	err := GenerateAndStoreAsK8SSecret(
@@ -150,6 +162,7 @@ func TestGenerateAndStoreAsK8SSecretSupportsTagging(t *testing.T) {
 		true,
 		"tls",
 		sampleTlsOptions,
+		dnsNames,
 	)
 	require.NoError(t, err)
 	secret := k8s.GetSecret(t, ttKubectlOptions, secretName)
@@ -192,6 +205,9 @@ func TestGenerateAndStoreAsK8SSecretAnnotatesAdditionalMetadata(t *testing.T) {
 				Annotations: map[string]string{},
 			}
 
+			// Setup Subject Alternitive DNS names to add to the certificate
+			var dnsNames []string = nil
+
 			// Generate the TLS certificate and then verify it created a Kubernetes Secret in the right namespace with the right
 			// name.
 			filenameBase := random.UniqueId()
@@ -202,6 +218,7 @@ func TestGenerateAndStoreAsK8SSecretAnnotatesAdditionalMetadata(t *testing.T) {
 				true,
 				filenameBase,
 				sampleTlsOptions,
+				dnsNames,
 			)
 			require.NoError(t, err)
 			secret := k8s.GetSecret(t, ttKubectlOptions, secretName)

--- a/tls/options.go
+++ b/tls/options.go
@@ -81,6 +81,7 @@ func (options *TLSOptions) GenerateAndStoreTLSCertificateKeyPair(
 	rootPath string,
 	keyPassword string,
 	isCA bool,
+	dnsNames []string,
 	signedBy *x509.Certificate,
 	signedByKey interface{}, // We don't know what format the signing key is in, so we will accept any type
 ) (CertificateKeyPairPath, error) {
@@ -92,9 +93,9 @@ func (options *TLSOptions) GenerateAndStoreTLSCertificateKeyPair(
 	}
 	switch options.PrivateKeyAlgorithm {
 	case ECDSAAlgorithm:
-		err = options.generateECDSATLSCertificateKeyPair(path, keyPassword, isCA, signedBy, signedByKey)
+		err = options.generateECDSATLSCertificateKeyPair(path, keyPassword, isCA, dnsNames, signedBy, signedByKey)
 	case RSAAlgorithm:
-		err = options.generateRSATLSCertificateKeyPair(path, keyPassword, isCA, signedBy, signedByKey)
+		err = options.generateRSATLSCertificateKeyPair(path, keyPassword, isCA, dnsNames, signedBy, signedByKey)
 	default:
 		err = errors.WithStackTrace(UnknownPrivateKeyAlgorithm{options.PrivateKeyAlgorithm})
 	}
@@ -105,10 +106,11 @@ func (options *TLSOptions) generateECDSATLSCertificateKeyPair(
 	certificateKeyPairPath CertificateKeyPairPath,
 	keyPassword string,
 	isCA bool,
+	dnsNames []string,
 	signedBy *x509.Certificate,
 	signedByKey interface{}, // We don't know what format the signing key is in, so we will accept any type
 ) error {
-	keypair, err := CreateECDSACertificateKeyPair(options.ValidityTimeSpan, options.DistinguishedName, signedBy, signedByKey, isCA, options.ECDSACurve)
+	keypair, err := CreateECDSACertificateKeyPair(options.ValidityTimeSpan, options.DistinguishedName, signedBy, signedByKey, isCA, dnsNames, options.ECDSACurve)
 	if err != nil {
 		return errors.WithStackTrace(err)
 	}
@@ -131,10 +133,11 @@ func (options *TLSOptions) generateRSATLSCertificateKeyPair(
 	certificateKeyPairPath CertificateKeyPairPath,
 	keyPassword string,
 	isCA bool,
+	dnsNames []string,
 	signedBy *x509.Certificate,
 	signedByKey interface{}, // We don't know what format the signing key is in, so we will accept any type
 ) error {
-	keypair, err := CreateRSACertificateKeyPair(options.ValidityTimeSpan, options.DistinguishedName, signedBy, signedByKey, isCA, options.RSABits)
+	keypair, err := CreateRSACertificateKeyPair(options.ValidityTimeSpan, options.DistinguishedName, signedBy, signedByKey, isCA, dnsNames, options.RSABits)
 	if err != nil {
 		return errors.WithStackTrace(err)
 	}

--- a/tls/rsa_cert.go
+++ b/tls/rsa_cert.go
@@ -31,6 +31,7 @@ func CreateRSACertificateKeyPair(
 	signedBy *x509.Certificate,
 	signedByKey interface{}, // We don't know what format the signing key is in, so we will accept any type
 	isCA bool,
+	dnsNames []string,
 	rsaBits int,
 ) (TLSRSACertificateKeyPair, error) {
 	privateKey, publicKey, err := CreateRSAKeyPair(rsaBits)
@@ -48,6 +49,7 @@ func CreateRSACertificateKeyPair(
 		distinguishedName,
 		signedBy,
 		isCA,
+		dnsNames,
 		publicKey,
 		signingKey,
 	)

--- a/tls/rsa_cert_test.go
+++ b/tls/rsa_cert_test.go
@@ -13,12 +13,12 @@ func TestCreateRSACertificateKeyPairSupportsSigningCerts(t *testing.T) {
 	t.Parallel()
 
 	distinguishedName := CreateSampleDistinguishedName(t)
-	caKeyPair, err := CreateRSACertificateKeyPair(1*time.Hour, distinguishedName, nil, nil, true, 2048)
+	caKeyPair, err := CreateRSACertificateKeyPair(1*time.Hour, distinguishedName, nil, nil, true, nil, 2048)
 	require.NoError(t, err)
 	caCert, err := caKeyPair.Certificate()
 	require.NoError(t, err)
 
-	signedKeyPair, err := CreateRSACertificateKeyPair(1*time.Hour, distinguishedName, caCert, caKeyPair.PrivateKey, false, 2048)
+	signedKeyPair, err := CreateRSACertificateKeyPair(1*time.Hour, distinguishedName, caCert, caKeyPair.PrivateKey, false, nil, 2048)
 	require.NoError(t, err)
 	signedCert, err := signedKeyPair.Certificate()
 	require.NoError(t, err)
@@ -40,12 +40,12 @@ func TestCreateRSACertificateKeyPairSupportsSigningByECDSACerts(t *testing.T) {
 	t.Parallel()
 
 	distinguishedName := CreateSampleDistinguishedName(t)
-	caKeyPair, err := CreateECDSACertificateKeyPair(1*time.Hour, distinguishedName, nil, nil, true, "P256")
+	caKeyPair, err := CreateECDSACertificateKeyPair(1*time.Hour, distinguishedName, nil, nil, true, nil, "P256")
 	require.NoError(t, err)
 	caCert, err := caKeyPair.Certificate()
 	require.NoError(t, err)
 
-	signedKeyPair, err := CreateRSACertificateKeyPair(1*time.Hour, distinguishedName, caCert, caKeyPair.PrivateKey, false, 2048)
+	signedKeyPair, err := CreateRSACertificateKeyPair(1*time.Hour, distinguishedName, caCert, caKeyPair.PrivateKey, false, nil, 2048)
 	require.NoError(t, err)
 	signedCert, err := signedKeyPair.Certificate()
 	require.NoError(t, err)


### PR DESCRIPTION
DNS Names in the Subject Alternative Name are required when calling a service via its DNS name. This is needed when tools like [FluxCD Helm Operator](https://github.com/fluxcd/helm-operator) as they comunicate with Tiller via its service rather than using portforwarding like the Helm client.

Even though Tiller will most likly only require a single DNS name entry I have added the ability to add multiple DNS names so this tool can create certificates for other applications that will require more than a single DNS name. To add more than a single DNS entry you pass in the flag `--tls-dns-name` multiple times with the required DNS names.

Example:

```
tls gen \
--namespace tiller \
--ca-secret-name tiller-namespace-tiller-ca-certs \
--ca-namespace kube-system
--secret-name tiller-tiller-certs \
--tls-dns-name tiller-deploy.tiller \
--tls-dns-name tiller-deploy.gruntwork.io \
--tls-common-name gruntwork.io \
--tls-org Gruntwork
```

This will fix #67