### PR TITLE
Grant ability to get the Tiller Deployment

### DIFF
--- a/cmd/helm.go
+++ b/cmd/helm.go
@@ -349,6 +349,7 @@ At least one of --%s, --%s, or --%s are required.`, RbacUserFlag, RbacGroupFlag,
 					tlsAlgorithmFlag,
 					tlsECDSACurveFlag,
 					tlsRSABitsFlag,
+					tillerDeploymentNameFlag,
 					helmKubectlContextNameFlag,
 					helmKubeconfigFlag,
 					helmKubectlServerFlag,
@@ -617,13 +618,14 @@ func grantHelmAccess(cliContext *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	tillerDeploymentName := cliContext.String(tillerDeploymentNameFlag.Name)
 	rbacGroups := cliContext.StringSlice(grantedRbacGroupsFlag.Name)
 	rbacUsers := cliContext.StringSlice(grantedRbacUsersFlag.Name)
 	serviceAccounts := cliContext.StringSlice(grantedServiceAccountsFlag.Name)
 	if len(rbacGroups) == 0 && len(rbacUsers) == 0 && len(serviceAccounts) == 0 {
 		return entrypoint.NewRequiredArgsError(fmt.Sprintf("At least one --%s, --%s, or --%s is required", RbacUserFlag, RbacGroupFlag, RbacServiceAccountFlag))
 	}
-	return helm.GrantAccess(kubectlOptions, tlsOptions, tillerNamespace, rbacGroups, rbacUsers, serviceAccounts)
+	return helm.GrantAccess(kubectlOptions, tlsOptions, tillerDeploymentName, tillerNamespace, rbacGroups, rbacUsers, serviceAccounts)
 }
 
 // revokeHelmAccess is the action function for the helm revoke command.

--- a/helm/deploy.go
+++ b/helm/deploy.go
@@ -269,7 +269,7 @@ func grantAndConfigureLocalClient(
 		return errors.WithStackTrace(UnknownRBACEntityType{localClientRBACEntity.EntityType()})
 	}
 
-	err := GrantAccess(kubectlOptions, tlsOptions, tillerNamespace, rbacGroups, rbacUsers, rbacServiceAccounts)
+	err := GrantAccess(kubectlOptions, tlsOptions, TillerDeploymentName, tillerNamespace, rbacGroups, rbacUsers, rbacServiceAccounts)
 	if err != nil {
 		return err
 	}

--- a/helm/test_helpers.go
+++ b/helm/test_helpers.go
@@ -26,7 +26,7 @@ func getHelmHome(t *testing.T) string {
 	return helmHome
 }
 
-func bindNamespaceAdminRole(t *testing.T, ttKubectlOptions *k8s.KubectlOptions, serviceAccountName string) {
+func bindNamespaceAdminRole(t *testing.T, ttKubectlOptions *k8s.KubectlOptions, serviceAccountNamespace string, serviceAccountName string) {
 	clientset, err := k8s.GetKubernetesClientFromOptionsE(t, ttKubectlOptions)
 	require.NoError(t, err)
 
@@ -52,7 +52,7 @@ func bindNamespaceAdminRole(t *testing.T, ttKubectlOptions *k8s.KubectlOptions, 
 				Kind:      "ServiceAccount",
 				APIGroup:  "",
 				Name:      serviceAccountName,
-				Namespace: ttKubectlOptions.Namespace,
+				Namespace: serviceAccountNamespace,
 			},
 		},
 		RoleRef: rbacv1.RoleRef{


### PR DESCRIPTION
This fixes an issue with using `helm grant` as the sole method to grant the minimal permissions for accessing tiller when using with [the terraform helm provider](https://github.com/terraform-providers/terraform-provider-helm).

Terraform helm provider attempts to retrieve the `Deployment` resource of Tiller to verify that is up before attempting to connect to it. Previously we did not grant enough permissions for that operation: this PR fixes that.