### PR TITLE
Introduce k8s kubectl

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The following commands are available as part of `kubergrunt`:
     * [revoke](#revoke)
 1. [k8s](#k8s)
     * [wait-for-ingress](#wait-for-ingress)
+    * [kubectl](#kubectl)
 1. [tls](#tls)
     * [gen](#gen)
 
@@ -508,6 +509,26 @@ this command will query the Kubernetes API to check the `Ingress` resource up to
 inbetween each try for a total of 150 seconds (2.5 minutes) before timing out.
 
 Run `kubergrunt k8s wait-for-ingress --help` to see all the available options.
+
+#### kubectl
+
+This subcommand will call out to kubectl with a temporary file that acts as the kubeconfig, set up with the parameters
+`--kubectl-server-endpoint`, `--kubectl-certificate-authority`, `--kubectl-token`. Unlike using kubectl directly, this
+command allows you to pass in the base64 encoded certificate authority data directly as opposed to as a file.
+
+To forward args to kubectl, pass all the args you wish to forward after a `--`. For example, the following command runs
+`kubectl get pods -n kube-system`:
+
+```
+kubergrunt k8s kubectl \
+  --kubectl-server-endpoint $SERVER_ENDPOINT \
+  --kubectl-certificate-authority $SERVER_CA \
+  --kubectl-token $TOKEN \
+  -- get pods -n kube-system
+```
+
+Run `kubergrunt k8s kubectl --help` to see all the available options.
+
 
 ### tls
 

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ corresponding release in the [Releases Page](/../../releases). You can download 
 platform from the releases page.
 
 Alternatively, you can install `kubergrunt` using the [Gruntwork
-Installer](https://github.com/gruntwork-io/gruntwork-installer). For example, to install version `v0.5.1`:
+Installer](https://github.com/gruntwork-io/gruntwork-installer). For example, to install version `v0.5.8`:
 
 ```bash
-gruntwork-install --binary-name "kubergrunt" --repo "https://github.com/gruntwork-io/kubergrunt" --tag "v0.5.1"
+gruntwork-install --binary-name "kubergrunt" --repo "https://github.com/gruntwork-io/kubergrunt" --tag "v0.5.8"
 ```
 
 

--- a/cmd/helm.go
+++ b/cmd/helm.go
@@ -97,15 +97,15 @@ var (
 	}
 	helmKubectlServerFlag = cli.StringFlag{
 		Name:  KubectlServerFlagName,
-		Usage: fmt.Sprintf("The Kubernetes server endpoint where the API is located. Overrides the settings in the kubeconfig. Must also set --%s and --%s.", KubectlCAFlagName, KubectlTokenFlagName),
+		Usage: fmt.Sprintf("The Kubernetes server endpoint where the API is located. Use in place of kubeconfig. Must also set --%s and --%s.", KubectlCAFlagName, KubectlTokenFlagName),
 	}
 	helmKubectlCAFlag = cli.StringFlag{
 		Name:  KubectlCAFlagName,
-		Usage: fmt.Sprintf("The base64 encoded certificate authority data in PEM format to use to validate the Kubernetes server. Overrides the settings in the kubeconfig. Must also set --%s and --%s.", KubectlServerFlagName, KubectlTokenFlagName),
+		Usage: fmt.Sprintf("The base64 encoded certificate authority data in PEM format to use to validate the Kubernetes server. Use in place of kubeconfig. Must also set --%s and --%s.", KubectlServerFlagName, KubectlTokenFlagName),
 	}
 	helmKubectlTokenFlag = cli.StringFlag{
 		Name:  KubectlTokenFlagName,
-		Usage: fmt.Sprintf("The bearer token to use to authenticate to the Kubernetes server API. Overrides the settings in the kubeconfig. Must also set --%s and --%s.", KubectlServerFlagName, KubectlCAFlagName),
+		Usage: fmt.Sprintf("The bearer token to use to authenticate to the Kubernetes server API. Use in place of kubeconfig. Must also set --%s and --%s.", KubectlServerFlagName, KubectlCAFlagName),
 	}
 
 	// Configurations for setting up the TLS certificates.

--- a/cmd/k8s.go
+++ b/cmd/k8s.go
@@ -44,15 +44,15 @@ var (
 	}
 	k8sKubectlServerFlag = cli.StringFlag{
 		Name:  KubectlServerFlagName,
-		Usage: fmt.Sprintf("The Kubernetes server endpoint where the API is located. Overrides the settings in the kubeconfig. Must also set --%s and --%s.", KubectlCAFlagName, KubectlTokenFlagName),
+		Usage: fmt.Sprintf("The Kubernetes server endpoint where the API is located. Use in place of kubeconfig. Must also set --%s and --%s.", KubectlCAFlagName, KubectlTokenFlagName),
 	}
 	k8sKubectlCAFlag = cli.StringFlag{
 		Name:  KubectlCAFlagName,
-		Usage: fmt.Sprintf("The base64 encoded certificate authority data in PEM format to use to validate the Kubernetes server. Overrides the settings in the kubeconfig. Must also set --%s and --%s.", KubectlServerFlagName, KubectlTokenFlagName),
+		Usage: fmt.Sprintf("The base64 encoded certificate authority data in PEM format to use to validate the Kubernetes server. Use in place of kubeconfig. Must also set --%s and --%s.", KubectlServerFlagName, KubectlTokenFlagName),
 	}
 	k8sKubectlTokenFlag = cli.StringFlag{
 		Name:  KubectlTokenFlagName,
-		Usage: fmt.Sprintf("The bearer token to use to authenticate to the Kubernetes server API. Overrides the settings in the kubeconfig. Must also set --%s and --%s.", KubectlServerFlagName, KubectlCAFlagName),
+		Usage: fmt.Sprintf("The bearer token to use to authenticate to the Kubernetes server API. Use in place of kubeconfig. Must also set --%s and --%s.", KubectlServerFlagName, KubectlCAFlagName),
 	}
 )
 

--- a/cmd/k8s.go
+++ b/cmd/k8s.go
@@ -85,6 +85,28 @@ You can configure the timeout settings using the --max-retries and --sleep-betwe
 					k8sKubectlTokenFlag,
 				},
 			},
+			cli.Command{
+				Name:  "kubectl",
+				Usage: "Thin wrapper around kubectl to rely on kubergrunt for temporarily authenticating to the cluster.",
+				Description: `This command will call out to kubectl with a temporary file that acts as the kubeconfig, set up with the parameters --kubectl-server-endpoint, --kubectl-certificate-authority, --kubectl-token. Unlike using kubectl directly, this command allows you to pass in the base64 encoded certificate authority data directly as opposed to as a file.
+
+To forward args to kubectl, pass all the args you wish to forward after a "--". For example, the following command runs "kubectl get pods -n kube-system":
+
+  kubergrunt k8s kubectl \
+    --kubectl-server-endpoint $SERVER_ENDPOINT \
+	--kubectl-certificate-authority $SERVER_CA \
+	--kubectl-token $TOKEN \
+	-- get pods -n kube-system`,
+				Action: kubectlWrapper,
+				Flags: []cli.Flag{
+					// Kubernetes auth flags
+					k8sKubectlContextNameFlag,
+					k8sKubeconfigFlag,
+					k8sKubectlServerFlag,
+					k8sKubectlCAFlag,
+					k8sKubectlTokenFlag,
+				},
+			},
 		},
 	}
 }
@@ -113,4 +135,21 @@ func waitForIngressEndpoint(cliContext *cli.Context) error {
 
 	// Now call waiting logic for the ingress endpoint
 	return kubectl.WaitUntilIngressEndpointProvisioned(kubectlOptions, namespace, ingressName, maxRetries, sleepBetweenRetries)
+}
+
+// kubectlWrapper is the action function for k8s kubectl command.
+func kubectlWrapper(cliContext *cli.Context) error {
+	// Extract Kubernetes auth information
+	kubectlOptions, err := parseKubectlOptions(cliContext)
+	if err != nil {
+		return err
+	}
+	return kubectl.RunKubectl(kubectlOptions, parseKubectlWrapperArgs(cliContext.Args())...)
+}
+
+func parseKubectlWrapperArgs(args cli.Args) []string {
+	if args.Get(0) == "--" {
+		return args[1:]
+	}
+	return args
 }


### PR DESCRIPTION
This introduces the `k8s kubectl` wrapper command, which can be used to run `kubectl` with the authentication parameters provided to `kubergrunt`.