### PR TITLE
Handle internal load balancers

### DIFF
--- a/kubectl/service.go
+++ b/kubectl/service.go
@@ -86,11 +86,15 @@ func GetLoadBalancerNameFromService(service corev1.Service) (string, error) {
 
 	// TODO: When expanding to GCP, update this logic
 
-	// For ELB, the subdomain will be NAME-TIME
+	// For ELB, the subdomain will be one of NAME-TIME or internal-NAME-TIME
 	loadbalancerHostnameSubDomain := strings.Split(loadbalancerHostname, ".")[0]
 	loadbalancerHostnameSubDomainParts := strings.Split(loadbalancerHostnameSubDomain, "-")
-	if len(loadbalancerHostnameSubDomainParts) != 2 {
+	numParts := len(loadbalancerHostnameSubDomainParts)
+	if numParts == 2 {
+		return loadbalancerHostnameSubDomainParts[0], nil
+	} else if numParts == 3 {
+		return loadbalancerHostnameSubDomainParts[1], nil
+	} else {
 		return "", NewLoadBalancerNameFormatError(loadbalancerHostname)
 	}
-	return loadbalancerHostnameSubDomainParts[0], nil
 }


### PR DESCRIPTION
This fixes a bug where internal load balancers were not handled correctly, due to them having a different naming scheme.

**NOTE**: Since this is with the rolling deployment feature, this can only be tested with an EKS cluster. For maintenance reasons, the integration tests with EKS is handled in our `terraform-aws-eks` repo. See https://github.com/gruntwork-io/terraform-aws-eks/pull/123 for the integration testing.