### PR TITLE
Add Kubernetes authentication option based on EKS

### DIFF
--- a/cmd/helm.go
+++ b/cmd/helm.go
@@ -83,31 +83,6 @@ var (
 		Usage: "The amount of time to sleep inbetween each check attempt. Accepted as a duration (5s, 10m, 1h).",
 	}
 
-	// Configurations for how to authenticate with the Kubernetes cluster.
-	// NOTE: this is the same as eksKubectlContextNameFlag and eksKubeconfigFlag, except the descriptions are updated to
-	// fit this series of subcommands.
-	helmKubectlContextNameFlag = cli.StringFlag{
-		Name:  KubectlContextNameFlagName,
-		Usage: "The kubectl config context to use for authenticating with the Kubernetes cluster.",
-	}
-	helmKubeconfigFlag = cli.StringFlag{
-		Name:   KubeconfigFlagName,
-		Usage:  "The path to the kubectl config file to use to authenticate with Kubernetes. You can also set this using the environment variable KUBECONFIG. (default: \"~/.kube/config\")",
-		EnvVar: "KUBECONFIG",
-	}
-	helmKubectlServerFlag = cli.StringFlag{
-		Name:  KubectlServerFlagName,
-		Usage: fmt.Sprintf("The Kubernetes server endpoint where the API is located. Use in place of kubeconfig. Must also set --%s and --%s.", KubectlCAFlagName, KubectlTokenFlagName),
-	}
-	helmKubectlCAFlag = cli.StringFlag{
-		Name:  KubectlCAFlagName,
-		Usage: fmt.Sprintf("The base64 encoded certificate authority data in PEM format to use to validate the Kubernetes server. Use in place of kubeconfig. Must also set --%s and --%s.", KubectlServerFlagName, KubectlTokenFlagName),
-	}
-	helmKubectlTokenFlag = cli.StringFlag{
-		Name:  KubectlTokenFlagName,
-		Usage: fmt.Sprintf("The bearer token to use to authenticate to the Kubernetes server API. Use in place of kubeconfig. Must also set --%s and --%s.", KubectlServerFlagName, KubectlCAFlagName),
-	}
-
 	// Configurations for setting up the TLS certificates.
 	// NOTE: the args for setting up the CA and server TLS certificates are defined in cmd/common.go
 	clientTLSSubjectJsonFlag = cli.StringFlag{
@@ -265,11 +240,12 @@ Additionally, this command will grant access to an RBAC entity and configure the
 					clientTLSStateFlag,
 					clientTLSCountryFlag,
 					helmHomeFlag,
-					helmKubectlContextNameFlag,
-					helmKubeconfigFlag,
-					helmKubectlServerFlag,
-					helmKubectlCAFlag,
-					helmKubectlTokenFlag,
+					genericKubectlContextNameFlag,
+					genericKubeconfigFlag,
+					genericKubectlServerFlag,
+					genericKubectlCAFlag,
+					genericKubectlTokenFlag,
+					genericKubectlEKSClusterArnFlag,
 				},
 			},
 			cli.Command{
@@ -284,11 +260,12 @@ Note: By default, this will not undeploy the Helm server if there are any deploy
 					undeployReleasesFlag,
 					helmHomeFlag,
 					tillerNamespaceFlag,
-					helmKubectlContextNameFlag,
-					helmKubeconfigFlag,
-					helmKubectlServerFlag,
-					helmKubectlCAFlag,
-					helmKubectlTokenFlag,
+					genericKubectlContextNameFlag,
+					genericKubeconfigFlag,
+					genericKubectlServerFlag,
+					genericKubectlCAFlag,
+					genericKubectlTokenFlag,
+					genericKubectlEKSClusterArnFlag,
 				},
 			},
 			cli.Command{
@@ -319,11 +296,12 @@ This allows you to use the configure command as a data source that is passed int
 					tillerNamespaceFlag,
 					resourceNamespaceFlag,
 					setKubectlNamespaceFlag,
-					helmKubectlContextNameFlag,
-					helmKubeconfigFlag,
-					helmKubectlServerFlag,
-					helmKubectlCAFlag,
-					helmKubectlTokenFlag,
+					genericKubectlContextNameFlag,
+					genericKubeconfigFlag,
+					genericKubectlServerFlag,
+					genericKubectlCAFlag,
+					genericKubectlTokenFlag,
+					genericKubectlEKSClusterArnFlag,
 					helmConfigureAsTFDataFlag,
 				},
 			},
@@ -351,11 +329,12 @@ At least one of --%s, --%s, or --%s are required.`, RbacUserFlag, RbacGroupFlag,
 					tlsECDSACurveFlag,
 					tlsRSABitsFlag,
 					tillerDeploymentNameFlag,
-					helmKubectlContextNameFlag,
-					helmKubeconfigFlag,
-					helmKubectlServerFlag,
-					helmKubectlCAFlag,
-					helmKubectlTokenFlag,
+					genericKubectlContextNameFlag,
+					genericKubeconfigFlag,
+					genericKubectlServerFlag,
+					genericKubectlCAFlag,
+					genericKubectlTokenFlag,
+					genericKubectlEKSClusterArnFlag,
 				},
 			},
 			cli.Command{
@@ -370,11 +349,12 @@ At least one of --%s, --%s, or --%s are required.`, RbacUserFlag, RbacGroupFlag,
 					revokedRbacGroupsFlag,
 					revokedRbacUsersFlag,
 					revokedServiceAccountsFlag,
-					helmKubectlContextNameFlag,
-					helmKubeconfigFlag,
-					helmKubectlServerFlag,
-					helmKubectlCAFlag,
-					helmKubectlTokenFlag,
+					genericKubectlContextNameFlag,
+					genericKubeconfigFlag,
+					genericKubectlServerFlag,
+					genericKubectlCAFlag,
+					genericKubectlTokenFlag,
+					genericKubectlEKSClusterArnFlag,
 				},
 			},
 			cli.Command{
@@ -391,11 +371,12 @@ You can configure the timeout settings using the --timeout and --sleep-between-r
 					expectedTillerVersionFlag,
 					tillerWaitTimeoutFlag,
 					tillerWaitSleepBetweenRetriesFlag,
-					helmKubectlContextNameFlag,
-					helmKubeconfigFlag,
-					helmKubectlServerFlag,
-					helmKubectlCAFlag,
-					helmKubectlTokenFlag,
+					genericKubectlContextNameFlag,
+					genericKubeconfigFlag,
+					genericKubectlServerFlag,
+					genericKubectlCAFlag,
+					genericKubectlTokenFlag,
+					genericKubectlEKSClusterArnFlag,
 				},
 			},
 		},

--- a/cmd/k8s.go
+++ b/cmd/k8s.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/gruntwork-io/gruntwork-cli/entrypoint"
@@ -30,30 +29,6 @@ var (
 		Value: 5 * time.Second,
 		Usage: "The amount of time to sleep inbetween each check attempt. Accepted as a duration (5s, 10m, 1h).",
 	}
-
-	// Configurations for how to authenticate with the Kubernetes cluster.
-	// NOTE: this is the same as helmKubectlContextNameFlag and helmKubeconfigFlag, except the descriptions are updated to
-	k8sKubectlContextNameFlag = cli.StringFlag{
-		Name:  KubectlContextNameFlagName,
-		Usage: "The kubectl config context to use for authenticating with the Kubernetes cluster.",
-	}
-	k8sKubeconfigFlag = cli.StringFlag{
-		Name:   KubeconfigFlagName,
-		Usage:  "The path to the kubectl config file to use to authenticate with Kubernetes. You can also set this using the environment variable KUBECONFIG. (default: \"~/.kube/config\")",
-		EnvVar: "KUBECONFIG",
-	}
-	k8sKubectlServerFlag = cli.StringFlag{
-		Name:  KubectlServerFlagName,
-		Usage: fmt.Sprintf("The Kubernetes server endpoint where the API is located. Use in place of kubeconfig. Must also set --%s and --%s.", KubectlCAFlagName, KubectlTokenFlagName),
-	}
-	k8sKubectlCAFlag = cli.StringFlag{
-		Name:  KubectlCAFlagName,
-		Usage: fmt.Sprintf("The base64 encoded certificate authority data in PEM format to use to validate the Kubernetes server. Use in place of kubeconfig. Must also set --%s and --%s.", KubectlServerFlagName, KubectlTokenFlagName),
-	}
-	k8sKubectlTokenFlag = cli.StringFlag{
-		Name:  KubectlTokenFlagName,
-		Usage: fmt.Sprintf("The bearer token to use to authenticate to the Kubernetes server API. Use in place of kubeconfig. Must also set --%s and --%s.", KubectlServerFlagName, KubectlCAFlagName),
-	}
 )
 
 func SetupK8SCommand() cli.Command {
@@ -78,11 +53,12 @@ You can configure the timeout settings using the --max-retries and --sleep-betwe
 					sleepBetweenRetriesFlag,
 
 					// Kubernetes auth flags
-					k8sKubectlContextNameFlag,
-					k8sKubeconfigFlag,
-					k8sKubectlServerFlag,
-					k8sKubectlCAFlag,
-					k8sKubectlTokenFlag,
+					genericKubectlContextNameFlag,
+					genericKubeconfigFlag,
+					genericKubectlServerFlag,
+					genericKubectlCAFlag,
+					genericKubectlTokenFlag,
+					genericKubectlEKSClusterArnFlag,
 				},
 			},
 			cli.Command{
@@ -100,11 +76,12 @@ To forward args to kubectl, pass all the args you wish to forward after a "--". 
 				Action: kubectlWrapper,
 				Flags: []cli.Flag{
 					// Kubernetes auth flags
-					k8sKubectlContextNameFlag,
-					k8sKubeconfigFlag,
-					k8sKubectlServerFlag,
-					k8sKubectlCAFlag,
-					k8sKubectlTokenFlag,
+					genericKubectlContextNameFlag,
+					genericKubeconfigFlag,
+					genericKubectlServerFlag,
+					genericKubectlCAFlag,
+					genericKubectlTokenFlag,
+					genericKubectlEKSClusterArnFlag,
 				},
 			},
 		},

--- a/cmd/tls.go
+++ b/cmd/tls.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/gruntwork-io/gruntwork-cli/entrypoint"
@@ -57,30 +56,6 @@ var (
 
 	// NOTE: Configurations for setting up the TLS certificates are defined in cmd/common.go
 
-	// Configurations for how to authenticate with the Kubernetes cluster.
-	// NOTE: this is the same as eksKubectlContextNameFlag and eksKubeconfigFlag, except the descriptions are updated to
-	// fit this series of subcommands.
-	tlsKubectlContextNameFlag = cli.StringFlag{
-		Name:  KubectlContextNameFlagName,
-		Usage: "The name to use for the config context that is set up to authenticate with the Kubernetes cluster.",
-	}
-	tlsKubeconfigFlag = cli.StringFlag{
-		Name:   KubeconfigFlagName,
-		Usage:  "The path to the kubectl config file to use to authenticate with Kubernetes. You can also set this using the environment variable KUBECONFIG. (default: \"~/.kube/config\")",
-		EnvVar: "KUBECONFIG",
-	}
-	tlsKubectlServerFlag = cli.StringFlag{
-		Name:  KubectlServerFlagName,
-		Usage: fmt.Sprintf("The Kubernetes server endpoint where the API is located. Overrides the settings in the kubeconfig. Must also set --%s and --%s.", KubectlCAFlagName, KubectlTokenFlagName),
-	}
-	tlsKubectlCAFlag = cli.StringFlag{
-		Name:  KubectlCAFlagName,
-		Usage: fmt.Sprintf("The base64 encoded certificate authority data in PEM format to use to validate the Kubernetes server. Overrides the settings in the kubeconfig. Must also set --%s and --%s.", KubectlServerFlagName, KubectlTokenFlagName),
-	}
-	tlsKubectlTokenFlag = cli.StringFlag{
-		Name:  KubectlTokenFlagName,
-		Usage: fmt.Sprintf("The bearer token to use to authenticate to the Kubernetes server API. Overrides the settings in the kubeconfig. Must also set --%s and --%s.", KubectlServerFlagName, KubectlCAFlagName),
-	}
 )
 
 func SetupTLSCommand() cli.Command {
@@ -124,11 +99,12 @@ Pass in a --ca-secret-name to sign the newly generated TLS key pair using the CA
 					tlsDNSNamesFlag,
 
 					// Kubernetes auth flags
-					tlsKubectlContextNameFlag,
-					tlsKubeconfigFlag,
-					tlsKubectlServerFlag,
-					tlsKubectlCAFlag,
-					tlsKubectlTokenFlag,
+					genericKubectlContextNameFlag,
+					genericKubeconfigFlag,
+					genericKubectlServerFlag,
+					genericKubectlCAFlag,
+					genericKubectlTokenFlag,
+					genericKubectlEKSClusterArnFlag,
 				},
 			},
 		},

--- a/eks/deploy.go
+++ b/eks/deploy.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/gruntwork-io/gruntwork-cli/errors"
 
+	"github.com/gruntwork-io/kubergrunt/eksawshelper"
 	"github.com/gruntwork-io/kubergrunt/kubectl"
 	"github.com/gruntwork-io/kubergrunt/logging"
 )
@@ -39,7 +40,7 @@ func RollOutDeployment(
 	logger.Infof("Beginning roll out for EKS cluster worker group %s in %s", eksAsgName, region)
 
 	// Construct clients for AWS
-	sess, err := NewAuthenticatedSession(region)
+	sess, err := eksawshelper.NewAuthenticatedSession(region)
 	if err != nil {
 		return errors.WithStackTrace(err)
 	}

--- a/eks/errors.go
+++ b/eks/errors.go
@@ -116,15 +116,6 @@ func NewLookupError(objectType string, objectId string, objectProperty string) L
 	return LookupError{objectProperty: objectProperty, objectType: objectType, objectId: objectId}
 }
 
-// CredentialsError is an error that occurs because AWS credentials can't be found.
-type CredentialsError struct {
-	UnderlyingErr error
-}
-
-func (err CredentialsError) Error() string {
-	return fmt.Sprintf("Error finding AWS credentials. Did you set the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables or configure an AWS profile? Underlying error: %v", err.UnderlyingErr)
-}
-
 // NoPeerCertificatesError is returned when we couldn't find any TLS peer certificates for the provided URL.
 type NoPeerCertificatesError struct {
 	URL string

--- a/eksawshelper/arn.go
+++ b/eksawshelper/arn.go
@@ -1,4 +1,4 @@
-package eks
+package eksawshelper
 
 import (
 	"strings"

--- a/eksawshelper/arn_test.go
+++ b/eksawshelper/arn_test.go
@@ -1,4 +1,4 @@
-package eks
+package eksawshelper
 
 import (
 	"testing"

--- a/eksawshelper/client.go
+++ b/eksawshelper/client.go
@@ -1,4 +1,4 @@
-package eks
+package eksawshelper
 
 import (
 	"github.com/aws/aws-sdk-go/aws"

--- a/eksawshelper/cluster.go
+++ b/eksawshelper/cluster.go
@@ -1,0 +1,59 @@
+package eksawshelper
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/eks"
+	"github.com/gruntwork-io/gruntwork-cli/errors"
+	"github.com/kubernetes-sigs/aws-iam-authenticator/pkg/token"
+
+	"github.com/gruntwork-io/kubergrunt/logging"
+)
+
+// GetClusterByArn returns the EKS Cluster object that corresponds to the given ARN.
+func GetClusterByArn(eksClusterArn string) (*eks.Cluster, error) {
+	logger := logging.GetProjectLogger()
+	logger.Infof("Retrieving details for EKS cluster %s", eksClusterArn)
+
+	region, err := GetRegionFromArn(eksClusterArn)
+	if err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+	logger.Infof("Detected cluster deployed in region %s", region)
+
+	client, err := NewEksClient(region)
+	if err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+
+	eksClusterName, err := GetClusterNameFromArn(eksClusterArn)
+	if err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+
+	describeClusterOutput, err := client.DescribeCluster(&eks.DescribeClusterInput{Name: aws.String(eksClusterName)})
+	if err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+
+	logger.Infof("Successfully retrieved EKS cluster details")
+
+	return describeClusterOutput.Cluster, nil
+}
+
+func GetKubernetesTokenForCluster(clusterID string) (*token.Token, string, error) {
+	gen, err := token.NewGenerator(false)
+	if err != nil {
+		return nil, "", errors.WithStackTrace(err)
+	}
+	tok, err := gen.Get(clusterID)
+	return &tok, gen.FormatJSON(tok), errors.WithStackTrace(err)
+}
+
+// NewEksClient creates an EKS client.
+func NewEksClient(region string) (*eks.EKS, error) {
+	sess, err := NewAuthenticatedSession(region)
+	if err != nil {
+		return nil, err
+	}
+	return eks.New(sess), nil
+}

--- a/eksawshelper/eksawshelper.go
+++ b/eksawshelper/eksawshelper.go
@@ -1,0 +1,3 @@
+// eksawshelper contains helper functions for accessing the AWS EKS API directly. This package exists to break cyclic
+// dependencies between eks and kubectl.
+package eksawshelper

--- a/eksawshelper/errors.go
+++ b/eksawshelper/errors.go
@@ -1,0 +1,12 @@
+package eksawshelper
+
+import "fmt"
+
+// CredentialsError is an error that occurs because AWS credentials can't be found.
+type CredentialsError struct {
+	UnderlyingErr error
+}
+
+func (err CredentialsError) Error() string {
+	return fmt.Sprintf("Error finding AWS credentials. Did you set the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables or configure an AWS profile? Underlying error: %v", err.UnderlyingErr)
+}

--- a/kubectl/command.go
+++ b/kubectl/command.go
@@ -1,10 +1,8 @@
 package kubectl
 
 import (
-	"io/ioutil"
 	"os"
 
-	"github.com/gruntwork-io/gruntwork-cli/errors"
 	"github.com/gruntwork-io/gruntwork-cli/shell"
 )
 
@@ -12,33 +10,25 @@ import (
 func RunKubectl(options *KubectlOptions, args ...string) error {
 	shellOptions := shell.NewShellOptions()
 	cmdArgs := []string{}
-	if options.Server != "" {
-		caFile, err := options.TempCAFile()
-		if err != nil {
-			return err
-		}
-		// Using direct auth, which contains secrets in the CLI args so mark as sensitive
-		shellOptions.SensitiveArgs = true
-		cmdArgs = append(cmdArgs, "--server", options.Server)
-		cmdArgs = append(cmdArgs, "--certificate-authority", caFile)
-		cmdArgs = append(cmdArgs, "--token", options.BearerToken)
-
-		// Create a temp file to use as the kubeconfig file. This avoids collision with existing servers that may
-		// overlap.
-		tmpConfigFile, err := ioutil.TempFile("", "")
-		if err != nil {
-			return errors.WithStackTrace(err)
-		}
-		tmpConfigFile.Close()
-		defer os.Remove(tmpConfigFile.Name())
-		cmdArgs = append(cmdArgs, "--kubeconfig", tmpConfigFile.Name())
-	} else {
+	scheme := options.AuthScheme()
+	switch scheme {
+	case ConfigBased:
 		if options.ContextName != "" {
 			cmdArgs = append(cmdArgs, "--context", options.ContextName)
 		}
 		if options.ConfigPath != "" {
 			cmdArgs = append(cmdArgs, "--kubeconfig", options.ConfigPath)
 		}
+	default:
+		tmpfile, err := options.TempConfigFromAuthInfo()
+		if tmpfile != "" {
+			// Make sure to delete the tmp file at the end
+			defer os.Remove(tmpfile)
+		}
+		if err != nil {
+			return err
+		}
+		cmdArgs = append(cmdArgs, "--kubeconfig", tmpfile)
 	}
 	cmdArgs = append(cmdArgs, args...)
 	_, err := shell.RunShellCommandAndGetAndStreamOutput(shellOptions, "kubectl", cmdArgs...)

--- a/kubectl/config.go
+++ b/kubectl/config.go
@@ -179,7 +179,7 @@ func LoadApiClientConfigFromOptions(options *KubectlOptions) (*restclient.Config
 		token = tokenRaw
 	default:
 		// This should never happen, but is required by the compiler
-		return nil, errors.WithStackTrace(AuthSchemeNotSupported{scheme})
+		return nil, errors.WithStackTrace(AuthSchemeNotSupported{authScheme})
 	}
 
 	config := &restclient.Config{

--- a/kubectl/config.go
+++ b/kubectl/config.go
@@ -178,7 +178,8 @@ func LoadApiClientConfigFromOptions(options *KubectlOptions) (*restclient.Config
 		server = serverRaw
 		token = tokenRaw
 	default:
-		// TODO: return an error
+		// This should never happen, but is required by the compiler
+		return nil, errors.WithStackTrace(AuthSchemeNotSupported{scheme})
 	}
 
 	config := &restclient.Config{

--- a/kubectl/config.go
+++ b/kubectl/config.go
@@ -140,26 +140,50 @@ func LoadConfigFromPath(path string) clientcmd.ClientConfig {
 	return config
 }
 
-// LoadApiClientConfig will load a ClientConfig object based on the provided KubectlOptions. Specifically, this will
-// create the config in memory if using direct auth, and load from disk if not.
+// LoadApiClientConfigFromOptions will load a ClientConfig object based on the provided KubectlOptions. Specifically,
+// this will create the config in memory if using direct auth, and load from disk if not.
 func LoadApiClientConfigFromOptions(options *KubectlOptions) (*restclient.Config, error) {
 	logger := logging.GetProjectLogger()
 
-	if options.Server == "" {
-		// Direct auth info is not filled in, so assume loading from file.
-		logger.Infof("No direct auth methods provided. Using config on disk and context.")
-		return LoadApiClientConfig(options.ConfigPath, options.ContextName)
-	}
+	var server, token string
+	var caData []byte
 
-	logger.Infof("Using direct auth methods to setup client.")
-	caData, err := base64.StdEncoding.DecodeString(options.Base64PEMCertificateAuthority)
-	if err != nil {
-		return nil, err
+	authScheme := options.AuthScheme()
+	switch authScheme {
+	case ConfigBased:
+		logger.Infof("Using config on disk and context.")
+		return LoadApiClientConfig(options.ConfigPath, options.ContextName)
+	// for the other two methods, we need to extract the server cadata and token to construct the client config
+	case DirectAuth:
+		logger.Infof("Using direct auth methods to setup client.")
+		caDataRaw, err := base64.StdEncoding.DecodeString(options.Base64PEMCertificateAuthority)
+		if err != nil {
+			return nil, err
+		}
+		caData = caDataRaw
+		server = options.Server
+		token = options.BearerToken
+	case EKSClusterBased:
+		serverRaw, b64PEMCA, tokenRaw, err := getKubeCredentialsFromEKSCluster(options.EKSClusterArn)
+		if err != nil {
+			return nil, err
+		}
+
+		caDataRaw, err := base64.StdEncoding.DecodeString(b64PEMCA)
+		if err != nil {
+			return nil, err
+		}
+
+		caData = caDataRaw
+		server = serverRaw
+		token = tokenRaw
+	default:
+		// TODO: return an error
 	}
 
 	config := &restclient.Config{
-		Host:        options.Server,
-		BearerToken: options.BearerToken,
+		Host:        server,
+		BearerToken: token,
 		ContentConfig: restclient.ContentConfig{
 			GroupVersion:         &corev1.SchemeGroupVersion,
 			NegotiatedSerializer: scheme.Codecs,

--- a/kubectl/config.go
+++ b/kubectl/config.go
@@ -164,19 +164,19 @@ func LoadApiClientConfigFromOptions(options *KubectlOptions) (*restclient.Config
 		server = options.Server
 		token = options.BearerToken
 	case EKSClusterBased:
-		serverRaw, b64PEMCA, tokenRaw, err := getKubeCredentialsFromEKSCluster(options.EKSClusterArn)
+		info, err := getKubeCredentialsFromEKSCluster(options.EKSClusterArn)
 		if err != nil {
 			return nil, err
 		}
 
-		caDataRaw, err := base64.StdEncoding.DecodeString(b64PEMCA)
+		caDataRaw, err := base64.StdEncoding.DecodeString(info.Base64PEMCertificateAuthority)
 		if err != nil {
 			return nil, err
 		}
 
 		caData = caDataRaw
-		server = serverRaw
-		token = tokenRaw
+		server = info.Server
+		token = info.BearerToken
 	default:
 		// This should never happen, but is required by the compiler
 		return nil, errors.WithStackTrace(AuthSchemeNotSupported{authScheme})

--- a/kubectl/errors.go
+++ b/kubectl/errors.go
@@ -27,6 +27,15 @@ func NewContextAlreadyExistsError(contextName string) ContextAlreadyExistsError 
 	return ContextAlreadyExistsError{contextName}
 }
 
+// AuthSchemeNotSupported is returned when the specified auth scheme in KubectlOptions is not supported.
+type AuthSchemeNotSupported struct {
+	scheme AuthScheme
+}
+
+func (err AuthSchemeNotSupported) Error() string {
+	return fmt.Sprintf("The auth scheme %s is not supported", authSchemeToString(err.scheme))
+}
+
 // NodeReadyTimeoutError is returned when we timeout waiting for nodes to reach ready state
 type NodeReadyTimeoutError struct {
 	numNodes int

--- a/kubectl/options.go
+++ b/kubectl/options.go
@@ -64,8 +64,8 @@ func (options *KubectlOptions) TempConfigFromAuthInfo() (string, error) {
 	default:
 		return "", errors.WithStackTrace(AuthSchemeNotSupported{scheme})
 	}
-	return tmpfile.Name(), err
 
+	return tmpfile.Name(), err
 }
 
 func tempConfigFromDirectAuthInfo(


### PR DESCRIPTION
This introduces a new authentication scheme for `kubergrunt`, where you can provide an EKS cluster ARN. In this auth scheme, we will do the following:

- Obtain a temporary authentication token from EKS for the k8s API.
- Create a new temp file to act as a kubeconfig file.
- Setup the default context in the temp kubeconfig to point to the EKS kubernetes API.
- Setup the default context in the temp kubeconfig file to use the auth token pulled down in step 1.

This allows you to do something like the following without setting up the kubeconfig with `eks configure`:

```
kubergrunt k8s kubectl --kubectl-eks-cluster-arn $EKS_CLUSTER_ARN -- get pods -n kube-system
```