### PR TITLE
Extend #89 with fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ jobs:
               --src-path ./cmd \
               --dest-path ./bin \
               --ld-flags "-X main.VERSION=$CIRCLE_TAG -extldflags '-static'"
-            cd ./bin && sha256sum * > SHA256SUMS
+            (cd ./bin && sha256sum * > SHA256SUMS)
             upload-github-release-assets ./bin/*
           no_output_timeout: 900s
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,6 +117,7 @@ jobs:
               --src-path ./cmd \
               --dest-path ./bin \
               --ld-flags "-X main.VERSION=$CIRCLE_TAG -extldflags '-static'"
+            cd ./bin && sha256sum * > SHA256SUMS
             upload-github-release-assets ./bin/*
           no_output_timeout: 900s
 


### PR DESCRIPTION
Since the `sha256sum` and `upload-github-release-assets` calls are in the same step, the `cd` call needs to be in a subshell.