### PR TITLE
Increase cleanup timeout to 5 minutes

### DIFF
--- a/eks/cleanup.go
+++ b/eks/cleanup.go
@@ -16,8 +16,8 @@ import (
 
 // Set wait variables for NetworkInterface detaching and deleting
 const (
-	waitSleepBetweenRetries time.Duration = 2 * time.Second
-	waitMaxRetries          int           = 60
+	waitSleepBetweenRetries time.Duration = 10 * time.Second
+	waitMaxRetries          int           = 30
 )
 
 // CleanupSecurityGroup deletes the AWS EKS managed security group, which otherwise doesn't get cleaned up when


### PR DESCRIPTION
Even though the terraform-aws-eks tests are passing on CI, when running the cleanup steps locally, increasing the timeout may help. I'm able to see that the cleanup does eventually resolve, but takes several tries. This PR increases the total timeout to 5 minutes, up from 2 minutes.