### PR TITLE
GroupName is only supported in default VPC and EC2-classic

### DIFF
--- a/eks/cleanup.go
+++ b/eks/cleanup.go
@@ -81,10 +81,7 @@ func CleanupSecurityGroup(
 			return errors.WithStackTrace(err)
 		}
 
-		input := &ec2.DeleteSecurityGroupInput{
-			GroupId:   aws.String(groupID),
-			GroupName: aws.String(groupName),
-		}
+		input := &ec2.DeleteSecurityGroupInput{GroupId: aws.String(groupID)}
 		_, err := ec2Svc.DeleteSecurityGroup(input)
 		if err != nil {
 			if awsErr, isAwsErr := err.(awserr.Error); isAwsErr && awsErr.Code() == "InvalidGroup.NotFound" {


### PR DESCRIPTION
If you look at the description for `GroupName` field on `DeleteSecurityGroup`, it will indicate that you should only set it for EC2-classic or the default VPC, neither of which we are using with EKS. Setting this seems harmless but it actually causes an error if there is no Default VPC in the account:

> ERROR: VPCIdNotSpecified: No default VPC for this user. GroupName is only supported for EC2-Classic and default VPC.
>       status code: 400, request id: 6b6221a7-f5ba-4700-b46a-56cb6d88e44d

https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#DeleteSecurityGroupInput