### PR TITLE
Patch for helm 2 compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,6 +129,8 @@ workflows:
         filters:
           tags:
             only: /^v.*/
+        context:
+        - Gruntwork Admin
 
     - kubergrunt_tests:
         requires:
@@ -136,6 +138,8 @@ workflows:
         filters:
           tags:
             only: /^v.*/
+        context:
+        - Gruntwork Admin
 
     - deploy:
         requires:
@@ -145,3 +149,5 @@ workflows:
             only: /^v.*/
           branches:
             ignore: /.*/
+        context:
+        - Gruntwork Admin

--- a/helm/home.go
+++ b/helm/home.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	StableRepositoryName = "stable"
-	StableRepositoryURL  = "https://kubernetes-charts.storage.googleapis.com"
+	StableRepositoryURL  = "https://charts.helm.sh/stable"
 )
 
 // GetDefaultHelmHome returns the default helm home directory, ~/.helm


### PR DESCRIPTION
This is a patch to `v0.5.13` to be compatible with the new location of the helm stable repository for customers who are still on Helm v2.

https://helm.sh/blog/new-location-stable-incubator-charts/