### PR TITLE
Add support for Kubernetes 1.19

### DIFF
--- a/eks/sync.go
+++ b/eks/sync.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gruntwork-io/kubergrunt/kubectl"
 	"github.com/gruntwork-io/kubergrunt/logging"
 )
+
 var (
 	// NOTE: Ensure that there is an entry for each supported version in the following tables.
 	supportedVersions = []string{"1.19", "1.18", "1.17", "1.16", "1.15", "1.14"}

--- a/eks/sync.go
+++ b/eks/sync.go
@@ -26,12 +26,12 @@ import (
 	"github.com/gruntwork-io/kubergrunt/kubectl"
 	"github.com/gruntwork-io/kubergrunt/logging"
 )
-
 var (
 	// NOTE: Ensure that there is an entry for each supported version in the following tables.
-	supportedVersions = []string{"1.18", "1.17", "1.16", "1.15", "1.14"}
+	supportedVersions = []string{"1.19", "1.18", "1.17", "1.16", "1.15", "1.14"}
 
 	coreDNSVersionLookupTable = map[string]string{
+		"1.19": "1.8.0-eksbuild.1",
 		"1.18": "1.7.0-eksbuild.1",
 		"1.17": "1.6.6-eksbuild.1",
 		"1.16": "1.6.6-eksbuild.1",
@@ -40,6 +40,7 @@ var (
 	}
 
 	kubeProxyVersionLookupTable = map[string]string{
+		"1.19": "1.19.6-eksbuild.1",
 		"1.18": "1.18.8-eksbuild.1",
 		"1.17": "1.17.9-eksbuild.1",
 		"1.16": "1.16.13-eksbuild.1",
@@ -48,6 +49,7 @@ var (
 	}
 
 	amazonVPCCNIVersionLookupTable = map[string]string{
+		"1.19": "1.7.5",
 		"1.18": "1.7.5",
 		"1.17": "1.7.5",
 		"1.16": "1.7.5",


### PR DESCRIPTION
Per https://github.com/gruntwork-io/kubergrunt/issues/111 I am adding support for EKS Kubernetes 1.19. I was able to upgrade a cluster with these changes. 

I used the versions in this chart.

https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html