### PR TITLE
Make deploy process not depend on tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
               --ld-flags "-X main.VERSION=$CIRCLE_TAG -extldflags '-static'"
             (cd ./bin && sha256sum * > SHA256SUMS)
             upload-github-release-assets ./bin/*
-          no_output_timeout: 900s
+          no_output_timeout: 1800s
 workflows:
   version: 2
   test-and-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,8 +81,6 @@ workflows:
           context:
             - Gruntwork Admin
       - deploy:
-          requires:
-            - kubergrunt_tests
           filters:
             tags:
               only: /^v.*/

--- a/eks/fixture/cleanup-test/attached-ni/main.tf
+++ b/eks/fixture/cleanup-test/attached-ni/main.tf
@@ -15,7 +15,7 @@ terraform {
 
 resource "aws_instance" "test" {
   ami           = data.aws_ami.ubuntu.id
-  instance_type = "t2.micro"
+  instance_type = module.instance_types.recommended_instance_type
   subnet_id     = module.floating_eni.subnet_id
 
   tags = {
@@ -33,6 +33,13 @@ module "floating_eni" {
   source = "../unattached-ni"
   prefix = var.prefix
 }
+
+module "instance_types" {
+  source = "git::git@github.com:gruntwork-io/terraform-aws-utilities.git//modules/instance-type?ref=v0.4.0"
+
+  instance_types = ["t2.micro", "t3.micro"]
+}
+
 
 # ---------------------------------------------------------------------------------------------------------------------
 # LOOK UP THE LATEST UBUNTU AMI


### PR DESCRIPTION
Due to the brittleness of integration testing, we should make sure the deploy process happens even if the tests fail (like we are doing in many of the other repos).

Fixes https://github.com/gruntwork-io/kubergrunt/issues/121