### PR TITLE
Always enable AWS shared configuration file support

### DIFF
--- a/eksawshelper/client.go
+++ b/eksawshelper/client.go
@@ -7,7 +7,11 @@ import (
 
 // NewAuthenticatedSession gets an AWS Session, checking that the user has credentials properly configured in their environment.
 func NewAuthenticatedSession(region string) (*session.Session, error) {
-	sess, err := session.NewSession(aws.NewConfig().WithRegion(region))
+	opts := session.Options{
+		Config:            *(aws.NewConfig().WithRegion(region)),
+		SharedConfigState: session.SharedConfigEnable,
+	}
+	sess, err := session.NewSessionWithOptions(opts)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Similar to what Hashicorp has done in Terraform (https://github.com/hashicorp/aws-sdk-go-base/pull/38), always enable AWS shared configuration file support. This way the `AWS_SDK_LOAD_CONFIG` env var no longer needs to be set to use named profiles.