### PR TITLE
getThumbprint now uses http client

### DIFF
--- a/eks/oidc.go
+++ b/eks/oidc.go
@@ -99,6 +99,7 @@ func getThumbprint(jwksURL string) (string, error) {
 	if err != nil {
 		return "", errors.WithStackTrace(err)
 	}
+	defer resp.Body.Close()
 
 	peerCerts := resp.TLS.PeerCertificates
 	numCerts := len(peerCerts)

--- a/eks/oidc.go
+++ b/eks/oidc.go
@@ -2,7 +2,6 @@ package eks
 
 import (
 	"crypto/sha1"
-	"crypto/tls"
 	"encoding/hex"
 	"encoding/json"
 	"io/ioutil"
@@ -96,15 +95,12 @@ func getThumbprint(jwksURL string) (string, error) {
 		hostname = net.JoinHostPort(hostname, "443")
 	}
 
-	tlsConfig := tls.Config{ServerName: parsedURL.Host}
-	conn, err := tls.Dial("tcp", hostname, &tlsConfig)
+	resp, err := http.Get("https://" + hostname)
 	if err != nil {
 		return "", errors.WithStackTrace(err)
 	}
-	defer conn.Close()
 
-	state := conn.ConnectionState()
-	peerCerts := state.PeerCertificates
+	peerCerts := resp.TLS.PeerCertificates
 	numCerts := len(peerCerts)
 	if numCerts == 0 {
 		return "", errors.WithStackTrace(NoPeerCertificatesError{jwksURL})


### PR DESCRIPTION
To avoid issues with the tool inside corporate networks, `getThumbprint` now uses the http client to pull TLS certificates. This uses the system proxy configuration.

Fixes #78