### PR TITLE
Add new functionality to cordon and drain nodes in an ASG

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ kubergrunt eks drain --asg-name my-asg --region us-east-2
 You can drain multiple ASGs by providing the `--name` option multiple times:
 
 ```bash
-kubergrunt eks drain --asg-name my-asg-a --name my-asg-b --name my-asg-b --region us-east-2
+kubergrunt eks drain --asg-name my-asg-a --name my-asg-b --name my-asg-c --region us-east-2
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The following commands are available as part of `kubergrunt`:
     * [sync-core-components](#sync-core-components)
     * [cleanup-security-group](#cleanup-security-group)
     * [schedule-coredns](#schedule-coredns)
+    * [drain](#drain)
 1. [k8s](#k8s)
     * [wait-for-ingress](#wait-for-ingress)
     * [kubectl](#kubectl)
@@ -309,6 +310,28 @@ kubergrunt eks schedule-coredns fargate --eks-cluster-name EKS_CLUSTER_NAME --fa
 ```bash
 kubergrunt eks schedule-coredns ec2 --eks-cluster-name EKS_CLUSTER_NAME --fargate-profile-arn FARGATE_PROFILE_ARN
 ```
+
+#### drain
+
+This subcommand can be used to drain Pods from the instances in the provided Auto Scaling Groups. This can be used to
+gracefully retire existing Auto Scaling Groups by ensuring the Pods are evicted in a manner that respects disruption
+budgets.
+
+You can read more about the drain operation in [the official
+documentation](https://kubernetes.io/docs/tasks/administer-cluster/safely-drain-node/).
+
+To drain the Auto Scaling Group `my-asg` in the region `us-east-2`:
+
+```bash
+kubergrunt eks drain --asg-name my-asg --region us-east-2
+```
+
+You can drain multiple ASGs by providing the `--name` option multiple times:
+
+```bash
+kubergrunt eks drain --asg-name my-asg-a --name my-asg-b --name my-asg-b --region us-east-2
+```
+
 
 ### k8s
 

--- a/cmd/eks.go
+++ b/cmd/eks.go
@@ -243,7 +243,7 @@ To drain the Auto Scaling Group "my-asg" in the region "us-east-2":
 
 You can also drain multiple ASGs by providing the "--asg-name" option multiple times:
 
-  kubergrunt eks drain --asg-name my-asg-a --asg-name my-asg-b --asg-name my-asg-b --region us-east-2
+  kubergrunt eks drain --asg-name my-asg-a --asg-name my-asg-b --asg-name my-asg-c --region us-east-2
 `,
 				Action: drainASG,
 				Flags: []cli.Flag{

--- a/cmd/eks.go
+++ b/cmd/eks.go
@@ -33,7 +33,7 @@ var (
 		Name:  "region",
 		Usage: "(Required) The AWS region code (e.g us-east-1) where the autoscaling group and EKS cluster is located.",
 	}
-	clusterAsgNameFlag = cli.StringFlag{
+	clusterAsgNameFlag = cli.StringSliceFlag{
 		Name:  "asg-name",
 		Usage: "(Required) The name of the autoscaling group that is a part of the EKS cluster.",
 	}
@@ -231,6 +231,35 @@ If max-retries is unspecified, this command will use a value that translates to 
 				},
 			},
 			cli.Command{
+				Name:  "drain",
+				Usage: "Drain all Pods from all instances in the provided Auto Scaling Groups.",
+				Description: `Drain Pods from the instances in the provided Auto Scaling Groups. This can be used to gracefully retire existing Auto Scaling Groups by ensuring the Pods are evicted in a manner that respects disruption budgets.
+
+You can read more about the drain operation in the official documentation: https://kubernetes.io/docs/tasks/administer-cluster/safely-drain-node/.
+
+To drain the Auto Scaling Group "my-asg" in the region "us-east-2":
+
+  kubergrunt eks drain --asg-name my-asg --region us-east-2
+
+You can also drain multiple ASGs by providing the "--asg-name" option multiple times:
+
+  kubergrunt eks drain --asg-name my-asg-a --asg-name my-asg-b --asg-name my-asg-b --region us-east-2
+`,
+				Action: drainASG,
+				Flags: []cli.Flag{
+					clusterRegionFlag,
+					clusterAsgNameFlag,
+					eksKubectlContextNameFlag,
+					genericKubeconfigFlag,
+					genericKubectlServerFlag,
+					genericKubectlCAFlag,
+					genericKubectlTokenFlag,
+					genericKubectlEKSClusterArnFlag,
+					drainTimeoutFlag,
+					deleteLocalDataFlag,
+				},
+			},
+			cli.Command{
 				Name:        "cleanup-security-group",
 				Usage:       "Delete the AWS-managed security group created for the EKS cluster.",
 				Description: "When destroying the EKS cluster, the AWS provider leaves behind the security group created for the EKS cluster. This command makes sure to clean up that resource. It can be called before or after the EKS cluster is destroyed. It must be called with the AWS-managed security-group-id for the EKS cluster, but it also finds other security groups by tag associated with the EKS cluster.",
@@ -349,10 +378,14 @@ func rollOutDeployment(cliContext *cli.Context) error {
 	if err != nil {
 		return errors.WithStackTrace(err)
 	}
-	asgName, err := entrypoint.StringFlagRequiredE(cliContext, clusterAsgNameFlag.Name)
-	if err != nil {
-		return errors.WithStackTrace(err)
+
+	// TODO: handle multiple ASGs correctly
+	asgNames := cliContext.StringSlice(clusterAsgNameFlag.Name)
+	if len(asgNames) != 1 {
+		return ExactlyOneASGErr{flagName: clusterAsgNameFlag.Name}
 	}
+	asgName := asgNames[0]
+
 	drainTimeout := cliContext.Duration(drainTimeoutFlag.Name)
 	deleteLocalData := cliContext.Bool(deleteLocalDataFlag.Name)
 	waitMaxRetries := cliContext.Int(waitMaxRetriesFlag.Name)
@@ -366,6 +399,34 @@ func rollOutDeployment(cliContext *cli.Context) error {
 		deleteLocalData,
 		waitMaxRetries,
 		waitSleepBetweenRetries,
+	)
+}
+
+// Command action for `kubergrunt eks drain`
+func drainASG(cliContext *cli.Context) error {
+	kubectlOptions, err := parseKubectlOptions(cliContext)
+	if err != nil {
+		return err
+	}
+
+	region, err := entrypoint.StringFlagRequiredE(cliContext, clusterRegionFlag.Name)
+	if err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	asgNames := cliContext.StringSlice(clusterAsgNameFlag.Name)
+	if len(asgNames) == 0 {
+		return entrypoint.NewRequiredArgsError("You must provide at least one ASG Name with --asg-name.")
+	}
+
+	drainTimeout := cliContext.Duration(drainTimeoutFlag.Name)
+	deleteLocalData := cliContext.Bool(deleteLocalDataFlag.Name)
+	return eks.DrainASG(
+		region,
+		asgNames,
+		kubectlOptions,
+		drainTimeout,
+		deleteLocalData,
 	)
 }
 

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -1,5 +1,7 @@
 package main
 
+import "fmt"
+
 // MutualExclusiveFlagError is returned when there is a violation of a mutually exclusive flag set.
 type MutuallyExclusiveFlagError struct {
 	Message string
@@ -7,4 +9,13 @@ type MutuallyExclusiveFlagError struct {
 
 func (err MutuallyExclusiveFlagError) Error() string {
 	return err.Message
+}
+
+// ExactlyOneASGErr is returned if a user does not provide exactly one ASG.
+type ExactlyOneASGErr struct {
+	flagName string
+}
+
+func (err ExactlyOneASGErr) Error() string {
+	return fmt.Sprintf("You must provide exactly one ASG using %s to this command.", err.flagName)
 }

--- a/eks/drain.go
+++ b/eks/drain.go
@@ -1,0 +1,63 @@
+package eks
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/gruntwork-io/go-commons/errors"
+	"github.com/gruntwork-io/kubergrunt/eksawshelper"
+	"github.com/gruntwork-io/kubergrunt/kubectl"
+	"github.com/gruntwork-io/kubergrunt/logging"
+)
+
+// DrainASG will cordon and drain all the instances associated with the given ASGs at the time of running.
+func DrainASG(
+	region string,
+	asgNames []string,
+	kubectlOptions *kubectl.KubectlOptions,
+	drainTimeout time.Duration,
+	deleteLocalData bool,
+) error {
+	logger := logging.GetProjectLogger()
+	logger.Infof("All instances in the following worker groups will be drained:")
+	for _, asgName := range asgNames {
+		logger.Infof("\t- %s", asgName)
+	}
+
+	// Construct clients for AWS
+	sess, err := eksawshelper.NewAuthenticatedSession(region)
+	if err != nil {
+		return errors.WithStackTrace(err)
+	}
+	asgSvc := autoscaling.New(sess)
+	ec2Svc := ec2.New(sess)
+	logger.Infof("Successfully authenticated with AWS")
+
+	// Retrieve instance IDs for each ASG requested.
+	allInstanceIDs := []string{}
+	for _, asgName := range asgNames {
+		_, currentInstanceIDs, err := getAsgInfo(asgSvc, asgName)
+		if err != nil {
+			return err
+		}
+		allInstanceIDs = append(allInstanceIDs, currentInstanceIDs...)
+	}
+	logger.Infof("Found %d instances across all requested ASGs.", len(allInstanceIDs))
+
+	// Cordon instances in the ASG to avoid scheduling evicted workloads on the instances being drained.
+	logger.Info("Cordoning instances in requested ASGs.")
+	if err := cordonNodesInAsg(ec2Svc, kubectlOptions, allInstanceIDs); err != nil {
+		return err
+	}
+	logger.Info("Successfully cordoned all instances in requested ASGs.")
+
+	// Now drain the pods from all the instances.
+	logger.Info("Draining Pods scheduled on instances in requested ASGs.")
+	if err := drainNodesInAsg(ec2Svc, kubectlOptions, allInstanceIDs, drainTimeout, deleteLocalData); err != nil {
+		return err
+	}
+	logger.Info("Successfully drained pods from all instances in requested ASGs.")
+
+	return nil
+}


### PR DESCRIPTION
This introduces a new command `kubergrunt eks drain` which can be used to cordon and drain all the instances in an ASG. This is useful when doing a blue-green replacement of the worker pools.