### PR TITLE
Add support for k8s 1.20 in sync command

### DIFF
--- a/eks/sync.go
+++ b/eks/sync.go
@@ -29,33 +29,30 @@ import (
 
 var (
 	// NOTE: Ensure that there is an entry for each supported version in the following tables.
-	supportedVersions = []string{"1.19", "1.18", "1.17", "1.16", "1.15", "1.14"}
+	supportedVersions = []string{"1.20", "1.19", "1.18", "1.17", "1.16"}
 
 	coreDNSVersionLookupTable = map[string]string{
+		"1.20": "1.8.3-eksbuild.1",
 		"1.19": "1.8.0-eksbuild.1",
 		"1.18": "1.7.0-eksbuild.1",
 		"1.17": "1.6.6-eksbuild.1",
 		"1.16": "1.6.6-eksbuild.1",
-		"1.15": "1.6.6-eksbuild.1",
-		"1.14": "1.6.6-eksbuild.1",
 	}
 
 	kubeProxyVersionLookupTable = map[string]string{
+		"1.20": "1.20.4-eksbuild.1",
 		"1.19": "1.19.6-eksbuild.1",
 		"1.18": "1.18.8-eksbuild.1",
 		"1.17": "1.17.9-eksbuild.1",
 		"1.16": "1.16.13-eksbuild.1",
-		"1.15": "1.15.11-eksbuild.1",
-		"1.14": "1.14.9-eksbuild.1",
 	}
 
 	amazonVPCCNIVersionLookupTable = map[string]string{
+		"1.20": "1.7.5",
 		"1.19": "1.7.5",
 		"1.18": "1.7.5",
 		"1.17": "1.7.5",
 		"1.16": "1.7.5",
-		"1.15": "1.7.5",
-		"1.14": "1.7.5",
 	}
 )
 


### PR DESCRIPTION
Also drops k8s 1.15 and 1.14, which is deprecated by EKS.