### PR TITLE
Add support for k8s v1.21

### DIFF
--- a/eks/sync.go
+++ b/eks/sync.go
@@ -30,9 +30,11 @@ import (
 
 var (
 	// NOTE: Ensure that there is an entry for each supported version in the following tables.
-	supportedVersions = []string{"1.20", "1.19", "1.18", "1.17", "1.16"}
+	supportedVersions = []string{"1.21", "1.20", "1.19", "1.18", "1.17", "1.16"}
 
+	// Reference: https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html
 	coreDNSVersionLookupTable = map[string]string{
+		"1.21": "1.8.3-eksbuild.1",
 		"1.20": "1.8.3-eksbuild.1",
 		"1.19": "1.8.0-eksbuild.1",
 		"1.18": "1.7.0-eksbuild.1",
@@ -40,20 +42,24 @@ var (
 		"1.16": "1.6.6-eksbuild.1",
 	}
 
+	// Reference: https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html#updating-kube-proxy-add-on
 	kubeProxyVersionLookupTable = map[string]string{
-		"1.20": "1.20.4-eksbuild.1",
-		"1.19": "1.19.6-eksbuild.1",
-		"1.18": "1.18.8-eksbuild.1",
-		"1.17": "1.17.9-eksbuild.1",
-		"1.16": "1.16.13-eksbuild.1",
+		"1.21": "1.21.2-eksbuild.2",
+		"1.20": "1.20.4-eksbuild.2",
+		"1.19": "1.19.6-eksbuild.2",
+		"1.18": "1.18.8-eksbuild.2",
+		"1.17": "1.17.9-eksbuild.2",
+		"1.16": "1.16.13-eksbuild.2",
 	}
 
+	// Reference: https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html
 	amazonVPCCNIVersionLookupTable = map[string]string{
-		"1.20": "1.7.5",
-		"1.19": "1.7.5",
-		"1.18": "1.7.5",
-		"1.17": "1.7.5",
-		"1.16": "1.7.5",
+		"1.21": "1.8.0",
+		"1.20": "1.8.0",
+		"1.19": "1.8.0",
+		"1.18": "1.8.0",
+		"1.17": "1.8.0",
+		"1.16": "1.8.0",
 	}
 )
 


### PR DESCRIPTION
- Adds support for k8s v1.21 to `sync-core-components` command
- Bump relevant versions to sync with latest referenced in EKS docs.