### PR TITLE
NLB based loadbalancer service support in eks deploy

### DIFF
--- a/commonerrors/commonerrors.go
+++ b/commonerrors/commonerrors.go
@@ -1,0 +1,15 @@
+// Package commonerrors contains error types that are common across the project.
+package commonerrors
+
+import "fmt"
+
+// ImpossibleErr is returned for impossible conditions that should never happen in the code. This error should only be
+// returned if there is no user remedy and represents a bug in the code.
+type ImpossibleErr string
+
+func (err ImpossibleErr) Error() string {
+	return fmt.Sprintf(
+		"You reached a point in kubergrunt that should not happen and is almost certainly a bug. Please open a GitHub issue on https://github.com/gruntwork-io/kubergrunt/issues with the contents of this error message. Code: %s",
+		string(err),
+	)
+}

--- a/eks/deploy.go
+++ b/eks/deploy.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/gruntwork-io/go-commons/errors"
 
 	"github.com/gruntwork-io/kubergrunt/eksawshelper"
@@ -47,6 +48,7 @@ func RollOutDeployment(
 	asgSvc := autoscaling.New(sess)
 	ec2Svc := ec2.New(sess)
 	elbSvc := elb.New(sess)
+	elbv2Svc := elbv2.New(sess)
 	logger.Infof("Successfully authenticated with AWS")
 
 	// Retrieve the ASG object and gather required info we will need later
@@ -89,6 +91,7 @@ func RollOutDeployment(
 		asgSvc,
 		ec2Svc,
 		elbSvc,
+		elbv2Svc,
 		kubectlOptions,
 		eksAsgName,
 		originalCapacity*2,

--- a/eks/elb.go
+++ b/eks/elb.go
@@ -1,0 +1,114 @@
+package eks
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/gruntwork-io/go-commons/collections"
+	"github.com/gruntwork-io/go-commons/errors"
+	"github.com/gruntwork-io/go-commons/retry"
+	"github.com/sirupsen/logrus"
+
+	"github.com/gruntwork-io/kubergrunt/commonerrors"
+)
+
+// waitForAnyInstancesRegisteredToALBOrNLB implements the logic to wait for instance registration to Application and
+// Network Load Balancers. Refer to function docs for waitForAnyInstancesRegisteredToELB for more info.
+// NOTE: this assumes the ELB is using the instance target type.
+func waitForAnyInstancesRegisteredToALBOrNLB(logger *logrus.Entry, elbv2Svc *elbv2.ELBV2, lbName string, instanceIDsToWaitFor []string) error {
+	targetGroup, err := getELBTargetGroup(elbv2Svc, lbName)
+	if err != nil {
+		return err
+	}
+
+	// Retry up to 10 minutes with 15 second retry sleep
+	waitErr := retry.DoWithRetry(
+		logger.Logger,
+		fmt.Sprintf(
+			"wait for expected targets to be registered to target group %s of load balancer %s",
+			aws.StringValue(targetGroup.TargetGroupName),
+			lbName,
+		),
+		40, 15*time.Second,
+		func() error {
+			targetsResp, err := elbv2Svc.DescribeTargetHealth(&elbv2.DescribeTargetHealthInput{TargetGroupArn: targetGroup.TargetGroupArn})
+			if err != nil {
+				return retry.FatalError{Underlying: err}
+			}
+
+			// Check each target to see if it is one of the instances we are waiting for, and return without error to
+			// stop the retry loop if that is the case since condition is met.
+			for _, targetHealth := range targetsResp.TargetHealthDescriptions {
+				if targetHealth.Target == nil || targetHealth.Target.Id == nil {
+					continue
+				}
+				instanceID := *targetHealth.Target.Id
+				if collections.ListContainsElement(instanceIDsToWaitFor, instanceID) {
+					return nil
+				}
+			}
+			return fmt.Errorf("No expected instances registered yet")
+		},
+	)
+	if fatalWaitErr, isFatalErr := waitErr.(retry.FatalError); isFatalErr {
+		return errors.WithStackTrace(fatalWaitErr.Underlying)
+	}
+	return errors.WithStackTrace(waitErr)
+}
+
+// waitForAnyInstancesRegisteredToCLB implements the logic to wait for instance registration to Classic Load Balancers.
+// Refer to function docs for waitForAnyInstancesRegisteredToELB for more info.
+func waitForAnyInstancesRegisteredToCLB(logger *logrus.Entry, elbSvc *elb.ELB, lbName string, instanceIds []string) error {
+	instances := []*elb.Instance{}
+	for _, instanceID := range instanceIds {
+		instances = append(instances, &elb.Instance{InstanceId: aws.String(instanceID)})
+	}
+
+	logger.Infof("Waiting for at least one instance to be in service for elb %s", lbName)
+	params := &elb.DescribeInstanceHealthInput{
+		LoadBalancerName: aws.String(lbName),
+		Instances:        instances,
+	}
+	err := elbSvc.WaitUntilAnyInstanceInService(params)
+	if err != nil {
+		logger.Errorf("error waiting for any instance to be in service for elb %s", lbName)
+		return err
+	}
+	logger.Infof("At least one instance in service for elb %s", lbName)
+	return nil
+}
+
+// getELBTargetGroup looks up the associated TargetGroup of the given ELB. Note that this assumes:
+// - lbName refers to a v2 ELB (ALB or NLB)
+// - There is exactly one TargetGroup associated with the ELB (this is enforced by the Kubernetes controllers)
+func getELBTargetGroup(elbv2Svc *elbv2.ELBV2, lbName string) (*elbv2.TargetGroup, error) {
+	resp, err := elbv2Svc.DescribeLoadBalancers(&elbv2.DescribeLoadBalancersInput{Names: aws.StringSlice([]string{lbName})})
+	if err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+
+	if len(resp.LoadBalancers) == 0 {
+		return nil, errors.WithStackTrace(CouldNotFindLoadBalancerErr{name: lbName})
+	} else if len(resp.LoadBalancers) > 1 {
+		// This condition is impossible because we are querying a single LB name and names are unique within regions.
+		return nil, errors.WithStackTrace(commonerrors.ImpossibleErr("MORE_THAN_ONE_ELB_IN_LOOKUP"))
+	} else if resp.LoadBalancers[0] == nil {
+		return nil, errors.WithStackTrace(commonerrors.ImpossibleErr("ELB_IS_NULL_FROM_API"))
+	}
+	elb := resp.LoadBalancers[0]
+
+	targetGroupsResp, err := elbv2Svc.DescribeTargetGroups(&elbv2.DescribeTargetGroupsInput{LoadBalancerArn: elb.LoadBalancerArn})
+	if err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+
+	if len(targetGroupsResp.TargetGroups) != 1 {
+		// This is an impossible condition because the load balancer controllers always only creates a single target
+		// group for the ELBs it provisions.
+		return nil, errors.WithStackTrace(commonerrors.ImpossibleErr("ELB_HAS_UNEXPECTED_NUMBER_OF_TARGET_GROUPS"))
+	}
+	return targetGroupsResp.TargetGroups[0], nil
+}

--- a/eks/errors.go
+++ b/eks/errors.go
@@ -168,3 +168,15 @@ func (err NetworkInterfaceDeletedTimeoutError) Error() string {
 		err.networkInterfaceId,
 	)
 }
+
+// CouldNotFindLoadBalancerErr is returned when the given ELB can not be found.
+type CouldNotFindLoadBalancerErr struct {
+	name string
+}
+
+func (err CouldNotFindLoadBalancerErr) Error() string {
+	return fmt.Sprintf(
+		"Could not find ELB with name %s.",
+		err.name,
+	)
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/gruntwork-io/go-commons v0.8.2
 	github.com/gruntwork-io/terratest v0.32.9
+	github.com/hashicorp/go-multierror v1.1.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/sirupsen/logrus v1.6.0
 	github.com/stretchr/testify v1.6.1

--- a/kubectl/errors.go
+++ b/kubectl/errors.go
@@ -55,64 +55,10 @@ type NodeDrainError struct {
 	NodeID string
 }
 
-// NodeDrainErrors is returned when there are errors draining nodes concurrently. Each node that has an error is added
-// to the list.
-type NodeDrainErrors struct {
-	errors []NodeDrainError
-}
-
-func (err NodeDrainErrors) Error() string {
-	base := "Multiple errors caught while draining a node:\n"
-	for _, subErr := range err.errors {
-		subErrMessage := fmt.Sprintf("Node %s: %s", subErr.NodeID, subErr.Error)
-		base = base + subErrMessage + "\n"
-	}
-	return base
-}
-
-func (err NodeDrainErrors) AddError(newErr NodeDrainError) {
-	err.errors = append(err.errors, newErr)
-}
-
-func (err NodeDrainErrors) IsEmpty() bool {
-	return len(err.errors) == 0
-}
-
-func NewNodeDrainErrors() NodeDrainErrors {
-	return NodeDrainErrors{[]NodeDrainError{}}
-}
-
 // NodeCordonError is returned when there is an error cordoning a node.
 type NodeCordonError struct {
 	Error  error
 	NodeID string
-}
-
-// NodeCordonErrors is returned when there are errors cordoning nodes concurrently. Each node that has an error is added
-// to the list.
-type NodeCordonErrors struct {
-	errors []NodeCordonError
-}
-
-func (err NodeCordonErrors) Error() string {
-	base := "Multiple errors caught while cordoning nodes:\n"
-	for _, subErr := range err.errors {
-		subErrMessage := fmt.Sprintf("Node %s: %s", subErr.NodeID, subErr.Error)
-		base = base + subErrMessage + "\n"
-	}
-	return base
-}
-
-func (err NodeCordonErrors) AddError(newErr NodeCordonError) {
-	err.errors = append(err.errors, newErr)
-}
-
-func (err NodeCordonErrors) IsEmpty() bool {
-	return len(err.errors) == 0
-}
-
-func NewNodeCordonErrors() NodeCordonErrors {
-	return NodeCordonErrors{[]NodeCordonError{}}
 }
 
 // LoadBalancerNotReadyError is returned when the LoadBalancer Service is unexpectedly not ready.

--- a/kubectl/errors.go
+++ b/kubectl/errors.go
@@ -154,3 +154,17 @@ func (err ProvisionIngressEndpointTimeoutError) Error() string {
 		err.namespace,
 	)
 }
+
+// UnknownAWSLoadBalancerTypeErr is returned when we encounter a load balancer type that we don't expect/support.
+type UnknownAWSLoadBalancerTypeErr struct {
+	typeKey string
+	typeStr string
+}
+
+func (err UnknownAWSLoadBalancerTypeErr) Error() string {
+	return fmt.Sprintf(
+		"Unknown value for annotation %s (value: %s)",
+		err.typeKey,
+		err.typeStr,
+	)
+}

--- a/kubectl/types.go
+++ b/kubectl/types.go
@@ -1,0 +1,28 @@
+package kubectl
+
+// AWSLoadBalancer is a struct that represents an AWS ELB that is associated with Kubernetes resources (Service or
+// Ingress).
+type AWSLoadBalancer struct {
+	Name       string
+	Type       ELBType
+	TargetType ELBTargetType
+}
+
+// ELBType represents the underlying type of the load balancer (classic, network, or application)
+type ELBType int
+
+const (
+	ALB ELBType = iota
+	NLB
+	CLB
+	UnknownELB
+)
+
+// ELBTargetType represents the different ways the AWS ELB routes to the services.
+type ELBTargetType int
+
+const (
+	InstanceTarget ELBTargetType = iota
+	IPTarget
+	UnknownELBTarget
+)


### PR DESCRIPTION
Fixes https://github.com/gruntwork-io/kubergrunt/issues/114

This also fixes error handling from `kubectl drain` and `kubectl cordon` commands that I noticed in testing.

Note that there is limited unit testing for these functions due to the amount of effort required in setting up the test case. Instead, we rely on integration testing from our `terraform-aws-eks` repo.