### PR TITLE
EKS kubernetes 1.21 actually uses coredns 1.8.4

### DIFF
--- a/eks/sync.go
+++ b/eks/sync.go
@@ -34,7 +34,7 @@ var (
 
 	// Reference: https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html
 	coreDNSVersionLookupTable = map[string]string{
-		"1.21": "1.8.3-eksbuild.1",
+		"1.21": "1.8.4-eksbuild.1",
 		"1.20": "1.8.3-eksbuild.1",
 		"1.19": "1.8.0-eksbuild.1",
 		"1.18": "1.7.0-eksbuild.1",


### PR DESCRIPTION
This is evidenced by this build log in our testing:

```
msg="Upgrading current deployed
version of coredns
(602401143452.dkr.ecr.us-east-1.amazonaws.com/eks/coredns:v1.8.4-eksbuild.1)
to match expected version
(602401143452.dkr.ecr.us-east-1.amazonaws.com/eks/coredns:v1.8.3-eksbuild.1)."
```

(Source build: https://app.circleci.com/pipelines/github/gruntwork-io/terraform-aws-service-catalog/4924/workflows/638807f6-71cd-43fc-b1a5-7cda5472b544/jobs/14589/steps)