### PR TITLE
Look for the latest eksbuild version to use for each region

### DIFF
--- a/eksawshelper/ecr.go
+++ b/eksawshelper/ecr.go
@@ -1,0 +1,77 @@
+package eksawshelper
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/gruntwork-io/go-commons/errors"
+	"github.com/gruntwork-io/kubergrunt/commonerrors"
+	"github.com/hashicorp/go-cleanhttp"
+)
+
+// TagExistsInRepo queries the ECR repository docker API to see if the given tag exists for the given ECR repository.
+func TagExistsInRepo(token, repoDomain, repoPath, tag string) (bool, error) {
+	manifestURL := fmt.Sprintf("https://%s/v2/%s/manifests/%s", repoDomain, repoPath, tag)
+	req, err := http.NewRequest("GET", manifestURL, nil)
+	if err != nil {
+		return false, errors.WithStackTrace(err)
+	}
+	req.Header.Set("Authorization", "Basic "+token)
+
+	httpClient := cleanhttp.DefaultClient()
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return false, errors.WithStackTrace(err)
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		return true, nil
+	case 404:
+		return false, nil
+	}
+
+	// All other status codes should be consider API errors.
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return false, errors.WithStackTrace(err)
+	}
+	return false, errors.WithStackTrace(ECRManifestFetchError{
+		manifestURL: manifestURL,
+		statusCode:  resp.StatusCode,
+		body:        string(body),
+	})
+}
+
+// GetDockerLoginToken retrieves an authorization token that can be used to access ECR via the docker APIs. The
+// return token can directly be used as a HTTP authorization header for basic auth.
+func GetDockerLoginToken(region string) (string, error) {
+	client, err := NewECRClient(region)
+	if err != nil {
+		return "", errors.WithStackTrace(err)
+	}
+
+	resp, err := client.GetAuthorizationToken(&ecr.GetAuthorizationTokenInput{})
+	if err != nil {
+		return "", errors.WithStackTrace(err)
+	}
+
+	if len(resp.AuthorizationData) != 1 {
+		// AWS docs mention that there is always one token returned on a successful response.
+		return "", errors.WithStackTrace(commonerrors.ImpossibleErr("AWS_DID_NOT_RETURN_DOCKER_TOKEN"))
+	}
+	return aws.StringValue(resp.AuthorizationData[0].AuthorizationToken), nil
+}
+
+// NewECRClient creates an AWS SDK client to access ECR API.
+func NewECRClient(region string) (*ecr.ECR, error) {
+	sess, err := NewAuthenticatedSession(region)
+	if err != nil {
+		return nil, err
+	}
+	return ecr.New(sess), nil
+}

--- a/eksawshelper/errors.go
+++ b/eksawshelper/errors.go
@@ -10,3 +10,14 @@ type CredentialsError struct {
 func (err CredentialsError) Error() string {
 	return fmt.Sprintf("Error finding AWS credentials. Did you set the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables or configure an AWS profile? Underlying error: %v", err.UnderlyingErr)
 }
+
+// ECRManifestFetchError is an error that occurs when retrieving information about a given tag in an ECR repository.
+type ECRManifestFetchError struct {
+	manifestURL string
+	statusCode  int
+	body        string
+}
+
+func (err ECRManifestFetchError) Error() string {
+	return fmt.Sprintf("Error querying ECR repo URL %s (status code %d) (response body %s)", err.manifestURL, err.statusCode, err.body)
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/gruntwork-io/go-commons v0.8.2
 	github.com/gruntwork-io/terratest v0.32.9
+	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/sirupsen/logrus v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -255,6 +255,8 @@ github.com/gruntwork-io/terratest v0.32.9 h1:ciWWJxISk06LAYImn6h1Vvir8hUz13VtwT2
 github.com/gruntwork-io/terratest v0.32.9/go.mod h1:FckR+7ks472IJfSKUPfPvnJfSxV1LKGWGMJ9m/LHegE=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
+github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-multierror v1.1.0 h1:B9UzwGQJehnUY1yNrnwREHc3fGbC2xefo8g4TbElacI=
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=


### PR DESCRIPTION
Fixes https://github.com/gruntwork-io/kubergrunt/issues/136

This PR addresses the issue by looking for the latest available `eksbuild` tag to use given a component tag base. I opted for doing it this way instead of relying on the component version table in the AWS docs because there is a `eksbuild.2` release in `us-east-1` for these components, suggesting that the version to use will be different depending on which region you are in.