### PR TITLE
Add unit tests for eksbuild tag finder

### DIFF
--- a/eksawshelper/ecr_test.go
+++ b/eksawshelper/ecr_test.go
@@ -1,0 +1,28 @@
+package eksawshelper
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTagExistsInRepo(t *testing.T) {
+	t.Parallel()
+
+	region := "us-west-2"
+	existingTag := "v1.18.8-eksbuild.1"
+	nonExistingTag := "v1.18.8-eksbuild.10"
+
+	token, err := GetDockerLoginToken(region)
+	require.NoError(t, err)
+	repoDomain := fmt.Sprintf("602401143452.dkr.ecr.%s.amazonaws.com", region)
+	tagExists1, err := TagExistsInRepo(token, repoDomain, "eks/kube-proxy", existingTag)
+	require.NoError(t, err)
+	assert.True(t, tagExists1)
+
+	tagExists2, err := TagExistsInRepo(token, repoDomain, "eks/kube-proxy", nonExistingTag)
+	require.NoError(t, err)
+	assert.False(t, tagExists2)
+}


### PR DESCRIPTION
This adds unit tests for the feature merged with https://github.com/gruntwork-io/kubergrunt/pull/137

NOTE: Earlier today, I launched an EKS cluster on `us-east-1` and definitely saw it use `eksbuild.2` for kubernetes version 1.18, but just now I checked and it was using `eksbuild.1`. AWS must have rolled it back or something because it is odd for it to suddenly go missing. In any case, I still think having this eksbuild lookup feature is useful because it will be robust to changes as EKS rolls out patches of their own.