### PR TITLE
Dynamically set the max size to the necessary capacity during rollout

### DIFF
--- a/eks/asg.go
+++ b/eks/asg.go
@@ -144,6 +144,25 @@ func setAsgCapacity(svc *autoscaling.AutoScaling, asgName string, desiredCapacit
 	return nil
 }
 
+// setAsgMaxSize will set the max size on the auto scaling group. Note that updating the max size does not typically
+// change the cluster size.
+func setAsgMaxSize(svc *autoscaling.AutoScaling, asgName string, maxSize int64) error {
+	logger := logging.GetProjectLogger()
+	logger.Infof("Updating ASG %s max size to %d.", asgName, maxSize)
+
+	input := autoscaling.UpdateAutoScalingGroupInput{
+		AutoScalingGroupName: aws.String(asgName),
+		MaxSize:              aws.Int64(maxSize),
+	}
+	_, err := svc.UpdateAutoScalingGroup(&input)
+	if err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	logger.Infof("Requested ASG %s max size to be %d.", asgName, maxSize)
+	return nil
+}
+
 // waitForCapacity waits for the desired capacity to be reached
 func waitForCapacity(
 	svc *autoscaling.AutoScaling,

--- a/eks/drain.go
+++ b/eks/drain.go
@@ -37,11 +37,11 @@ func DrainASG(
 	// Retrieve instance IDs for each ASG requested.
 	allInstanceIDs := []string{}
 	for _, asgName := range asgNames {
-		_, currentInstanceIDs, err := getAsgInfo(asgSvc, asgName)
+		asgInfo, err := getAsgInfo(asgSvc, asgName)
 		if err != nil {
 			return err
 		}
-		allInstanceIDs = append(allInstanceIDs, currentInstanceIDs...)
+		allInstanceIDs = append(allInstanceIDs, asgInfo.currentInstanceIDs...)
 	}
 	logger.Infof("Found %d instances across all requested ASGs.", len(allInstanceIDs))
 


### PR DESCRIPTION
This addresses a limitation with the current deployment rollout, where it is dependent on the `max_size` being set to a sufficiently large capacity. However, for certain use cases, this is undesirable as the `max_size` and `min_size` may be used to force the ASG capacity.

For example, some modules want to set the `auto_scaling_group` resource to `ignore_changes` on the `desired_capacity` to allow for use of the `cluster-autoscaler`. Users who want to use the same module without cluster-autoscaler must set the `min_size` and `max_size` to be the equivalent value to control the cluster size. For these use cases, having `kubergrunt` dynamically update the ASG `max_size` is desirable. Note that this also works for use cases with the `cluster-autoscaler`, where the `desired_capacity` may be set at values closer to the `max_size` during scale out events.