### PR TITLE
Fix sync to work with additional regions

### DIFF
--- a/eks/sync.go
+++ b/eks/sync.go
@@ -30,9 +30,8 @@ import (
 )
 
 const (
-	containerAccountID = "602401143452"
-	kubeProxyRepoPath  = "eks/kube-proxy"
-	coreDNSRepoPath    = "eks/coredns"
+	kubeProxyRepoPath = "eks/kube-proxy"
+	coreDNSRepoPath   = "eks/coredns"
 
 	// Largest eksbuild tag we will try looking for.
 	maxEKSBuild = 10
@@ -70,6 +69,19 @@ var (
 		"1.18": "1.9.0",
 		"1.17": "1.9.0",
 		"1.16": "1.9.0",
+	}
+
+	defaultContainerImageAccount = "602401143452"
+	// Reference: https://docs.aws.amazon.com/eks/latest/userguide/add-ons-images.html
+	containerImageAccountLookupTable = map[string]string{
+		"af-south-1":     "877085696533",
+		"ap-east-1":      "800184023465",
+		"cn-north-1":     "918309763551",
+		"cn-northwest-1": "961992271922",
+		"eu-south-1":     "590381155156",
+		"me-south-1":     "558608220178",
+		"us-gov-east-1":  "151742754352",
+		"us-gov-west-1":  "013241004608",
 	}
 )
 
@@ -646,5 +658,9 @@ func findLatestEKSBuild(token, repoDomain, repoPath, tagBase string) (string, er
 
 // getRepoDomain is a conveniency function to construct the ECR docker repo URL domain.
 func getRepoDomain(region string) string {
+	containerAccountID := defaultContainerImageAccount
+	if id, ok := containerImageAccountLookupTable[region]; ok {
+		containerAccountID = id
+	}
 	return fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com", containerAccountID, region)
 }

--- a/eks/sync_test.go
+++ b/eks/sync_test.go
@@ -2,6 +2,7 @@ package eks
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -16,6 +17,20 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func TestGetEKSContainerImageURL(t *testing.T) {
+	t.Parallel()
+
+	region := "us-west-2"
+	expected := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com", defaultContainerImageAccount, region)
+	actual := getRepoDomain(region)
+	assert.Equal(t, expected, actual)
+
+	region = "ap-east-1"
+	expected = fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com", containerImageAccountLookupTable[region], region)
+	actual = getRepoDomain(region)
+	assert.Equal(t, expected, actual)
+}
 
 func TestGetBaseURLForVPCCNIManifest(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://docs.gruntwork.io/guides/contributing/, or
  ask in this Pull Request and a Gruntwork core maintainer will be happy to help :)
  Note: Remember to add '[WIP]' to the beginning of the title if this PR is still a work-in-progress.
-->

## Description
Previously, the EKS add-on container image account was hard coded to a single account ID. However, [in some regions, the account ID differs](https://docs.aws.amazon.com/eks/latest/userguide/add-ons-images.html). This update adjusts the ECR repo URL to work in those regions.

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  If this is a feature PR, then where is it documented?

  - If docs exist:
    - Update any references, if relevant.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

<!-- Important: Did you make any backwards incompatible changes? If yes, then you must write a migration guide! -->

## TODOs

- [ ] Ensure the branch is named correctly with the issue number. e.g: `feature/new-vpc-endpoints-955` or `bug/missing-count-param-434`.
- [ ] Update the docs.
- [ ] Keep the changes backwards compatible where possible.
- [ ] Run the pre-commit checks successfully.
- [ ] Run the relevant tests successfully.
- [ ] Ensure any 3rd party code adheres with our license policy: https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378
- [ ] _Maintainers Only._ If necessary, release a new version of this repo.
- [ ] _Maintainers Only._ If there were backwards incompatible changes, include a migration guide in the release notes.
- [ ] _Maintainers Only._ Add to the next version of the monthly newsletter (see https://www.notion.so/gruntwork/Monthly-Newsletter-9198cbe7f8914d4abce23dca7b435f43).


## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
