### PR TITLE
Add support for 1.22 and drop support of 1.18, 1.17, and 1.16

### DIFF
--- a/eks/sync.go
+++ b/eks/sync.go
@@ -39,36 +39,30 @@ const (
 
 var (
 	// NOTE: Ensure that there is an entry for each supported version in the following tables.
-	supportedVersions = []string{"1.21", "1.20", "1.19", "1.18", "1.17", "1.16"}
+	supportedVersions = []string{"1.22", "1.21", "1.20", "1.19"}
 
 	// Reference: https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html
 	coreDNSVersionLookupTable = map[string]string{
+		"1.22": "1.8.7-eksbuild",
 		"1.21": "1.8.4-eksbuild",
 		"1.20": "1.8.3-eksbuild",
 		"1.19": "1.8.0-eksbuild",
-		"1.18": "1.7.0-eksbuild",
-		"1.17": "1.6.6-eksbuild",
-		"1.16": "1.6.6-eksbuild",
 	}
 
 	// Reference: https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html#updating-kube-proxy-add-on
 	kubeProxyVersionLookupTable = map[string]string{
+		"1.22": "1.22.6-eksbuild",
 		"1.21": "1.21.2-eksbuild",
 		"1.20": "1.20.4-eksbuild",
 		"1.19": "1.19.6-eksbuild",
-		"1.18": "1.18.8-eksbuild",
-		"1.17": "1.17.9-eksbuild",
-		"1.16": "1.16.13-eksbuild",
 	}
 
 	// Reference: https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html
 	amazonVPCCNIVersionLookupTable = map[string]string{
-		"1.21": "1.9.0",
-		"1.20": "1.9.0",
-		"1.19": "1.9.0",
-		"1.18": "1.9.0",
-		"1.17": "1.9.0",
-		"1.16": "1.9.0",
+		"1.22": "1.10.2",
+		"1.21": "1.10.2",
+		"1.20": "1.10.2",
+		"1.19": "1.10.2",
 	}
 
 	defaultContainerImageAccount = "602401143452"

--- a/eks/sync.go
+++ b/eks/sync.go
@@ -497,14 +497,7 @@ func getCorednsClusterRole(clientset *kubernetes.Clientset) (*rbacv1.ClusterRole
 // getBaseURLForVPCCNIManifest returns the base github URL where the manifest for the VPC CNI is located given the
 // requested version.
 func getBaseURLForVPCCNIManifest(vpcCNIVersion string) (string, error) {
-	// Extract the major and minor version of the VPC CNI version as it is needed to construct the URL for the
-	// deployment config.
-	parsedVPCCNIVersion, err := semver.Make(vpcCNIVersion)
-	if err != nil {
-		return "", err
-	}
-	majorMinorVPCCNIVersion := fmt.Sprintf("%d.%d", parsedVPCCNIVersion.Major, parsedVPCCNIVersion.Minor)
-	baseURL := fmt.Sprintf("https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/v%s/config/v%s/", vpcCNIVersion, majorMinorVPCCNIVersion)
+	baseURL := fmt.Sprintf("https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/v%s/config/master/", vpcCNIVersion)
 	return baseURL, nil
 }
 

--- a/eks/sync_test.go
+++ b/eks/sync_test.go
@@ -204,7 +204,7 @@ func TestFindLatestEKSBuild(t *testing.T) {
 		expectedVersion string
 	}{
 		{"1.20", "us-east-1", "1.20.4-eksbuild.2"},
-		{"1.16", "us-east-1", "1.16.13-eksbuild.1"},
+		{"1.19", "us-east-1", "1.19.6-eksbuild.1"},
 	}
 
 	for _, tc := range testCase {

--- a/eks/sync_test.go
+++ b/eks/sync_test.go
@@ -204,7 +204,7 @@ func TestFindLatestEKSBuild(t *testing.T) {
 		expectedVersion string
 	}{
 		{"1.20", "us-east-1", "1.20.4-eksbuild.2"},
-		{"1.19", "us-east-1", "1.19.6-eksbuild.1"},
+		{"1.22", "us-east-1", "1.22.6-eksbuild.1"},
 	}
 
 	for _, tc := range testCase {

--- a/eks/sync_test.go
+++ b/eks/sync_test.go
@@ -32,14 +32,6 @@ func TestGetEKSContainerImageURL(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
-func TestGetBaseURLForVPCCNIManifest(t *testing.T) {
-	t.Parallel()
-	expected := "https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/v1.7.5/config/v1.7/"
-	actual, err := getBaseURLForVPCCNIManifest("1.7.5")
-	require.NoError(t, err)
-	assert.Equal(t, expected, actual)
-}
-
 func TestDownloadVPCCNIManifestAndUpdateRegion(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://docs.gruntwork.io/guides/contributing/, or
  ask in this Pull Request and a Gruntwork core maintainer will be happy to help :)
  Note: Remember to add '[WIP]' to the beginning of the title if this PR is still a work-in-progress.
-->

## Description

This PR updates the `eks sync-core-components` command to add support for k8s version 1.22. This also removes support for 1.18, 1.17, and 1.16, which [has reached end of support in EKS](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar).

I also went ahead and synced the version of vpc CNI to the one advertised on the EKS page. Note that as a result of this, I had to simplify the `GetBaseURL` routine - the VPC CNI config is now simplified to not include the major-minor version of CNI. See https://github.com/aws/amazon-vpc-cni-k8s/tree/master/config


## TODOs

- [x] Ensure the branch is named correctly with the issue number. e.g: `feature/new-vpc-endpoints-955` or `bug/missing-count-param-434`.
- [x] Update the docs.
- [x] Keep the changes backwards compatible where possible.
- [x] Run the pre-commit checks successfully.
- [x] Run the relevant tests successfully.

## Related

Integration test is happening on https://github.com/gruntwork-io/terraform-aws-eks/pull/431