### PR TITLE
Data source: use aws_subnets over aws_subnet_ids

### DIFF
--- a/eks/fixture/cleanup-test/unattached-ni/main.tf
+++ b/eks/fixture/cleanup-test/unattached-ni/main.tf
@@ -62,5 +62,8 @@ data "aws_vpc" "default" {
 }
 
 data "aws_subnets" "default" {
-  vpc_id = data.aws_vpc.default.id
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
 }

--- a/eks/fixture/cleanup-test/unattached-ni/main.tf
+++ b/eks/fixture/cleanup-test/unattached-ni/main.tf
@@ -49,7 +49,7 @@ resource "aws_network_interface" "allow_tls" {
 }
 
 locals {
-  first_subnet = sort(tolist(data.aws_subnet_ids.default.ids))[0]
+  first_subnet = sort(tolist(data.aws_subnets.default.ids))[0]
 }
 
 
@@ -61,6 +61,6 @@ data "aws_vpc" "default" {
   default = true
 }
 
-data "aws_subnet_ids" "default" {
+data "aws_subnets" "default" {
   vpc_id = data.aws_vpc.default.id
 }


### PR DESCRIPTION
## Description

Addresses _internal_ aws v4 compatibility.

This updates example code only. The provider version handles both old and new data sources, so users have no updates to make on their end as a result of this change. It is backward compatible. When we bump the provider version to at least 3.75 _and/or_ remove the 4.x lock, that's when we have a potential backward incompatibility, but most likely, even that update will be functionally backward compatible, i.e., only require an update to the provider version, and no config changes, imports, or state migrations.

### Documentation

N/A

## TODOs

- [x] Ensure the branch is named correctly with the issue number. e.g: `feature/new-vpc-endpoints-955` or `bug/missing-count-param-434`.
- [x] Update the docs.
- [x] Keep the changes backwards compatible where possible.
- [x] Run the pre-commit checks successfully.
- [x] Run the relevant tests successfully.
- ~Ensure any 3rd party code adheres with our license policy: https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378~
- [ ] _Maintainers Only._ If necessary, release a new version of this repo.
- ~_Maintainers Only._ If there were backwards incompatible changes, include a migration guide in the release notes.~
- [ ] _Maintainers Only._ Add to the next version of the monthly newsletter (see https://www.notion.so/gruntwork/Monthly-Newsletter-9198cbe7f8914d4abce23dca7b435f43).


## Related Issues
Addresses https://github.com/gruntwork-io/cloud-chasers/issues/20
