### PR TITLE
Use client.authentication.k8s.io/v1beta1 API for kubeconfig

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ defaults: &defaults
     PACKER_VERSION: NONE
     GOLANG_VERSION: 1.16
     GO111MODULE: auto
-    KUBECTL_VERSION: v1.17.12
+    KUBECTL_VERSION: v1.22.6
     MINIKUBE_VERSION: v1.22.0
     KUBECONFIG: /home/circleci/.kube/config
 install_gruntwork_utils: &install_gruntwork_utils

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,9 @@ jobs:
       - run:
           command: |
             cd /home/circleci
+
+            sudo apt-get update
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y conntrack
             setup-minikube --minikube-version "${MINIKUBE_VERSION}" --k8s-version "${KUBECTL_VERSION}"
       - run:
           name: run kubergrunt tests

--- a/kubectl/config.go
+++ b/kubectl/config.go
@@ -111,7 +111,7 @@ func AddEksAuthInfoToConfig(config *api.Config, eksClusterArnString string, eksC
 	}
 
 	execConfig := api.ExecConfig{
-		APIVersion: "client.authentication.k8s.io/v1alpha1",
+		APIVersion: "client.authentication.k8s.io/v1beta1",
 		Command:    executablePath,
 		Args: []string{
 			"--loglevel",


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

`client.authentication.k8s.io/v1alpha1` is removed starting with 1.22, so this PR switches the default auth API to v1beta1 for the generated kubeconfig when using `eks configure`.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated the default client authentication API to `v1beta1` instead of `v1alpha1`.