### PR TITLE
Add support for 1.23 and drop support of 1.19

### DIFF
--- a/eks/sync.go
+++ b/eks/sync.go
@@ -39,30 +39,30 @@ const (
 
 var (
 	// NOTE: Ensure that there is an entry for each supported version in the following tables.
-	supportedVersions = []string{"1.22", "1.21", "1.20", "1.19"}
+	supportedVersions = []string{"1.23", "1.22", "1.21", "1.20"}
 
 	// Reference: https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html
 	coreDNSVersionLookupTable = map[string]string{
+		"1.23": "1.8.7-eksbuild",
 		"1.22": "1.8.7-eksbuild",
 		"1.21": "1.8.4-eksbuild",
 		"1.20": "1.8.3-eksbuild",
-		"1.19": "1.8.0-eksbuild",
 	}
 
 	// Reference: https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html#updating-kube-proxy-add-on
 	kubeProxyVersionLookupTable = map[string]string{
-		"1.22": "1.22.6-eksbuild",
-		"1.21": "1.21.2-eksbuild",
-		"1.20": "1.20.4-eksbuild",
-		"1.19": "1.19.6-eksbuild",
+		"1.23": "1.23.7-minimal-eksbuild",
+		"1.22": "1.22.11-eksbuild",
+		"1.21": "1.21.14-eksbuild",
+		"1.20": "1.20.15-eksbuild",
 	}
 
 	// Reference: https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html
 	amazonVPCCNIVersionLookupTable = map[string]string{
-		"1.22": "1.10.2",
-		"1.21": "1.10.2",
-		"1.20": "1.10.2",
-		"1.19": "1.10.2",
+		"1.23": "1.11.3",
+		"1.22": "1.11.3",
+		"1.21": "1.11.3",
+		"1.20": "1.11.3",
 	}
 
 	defaultContainerImageAccount = "602401143452"

--- a/eks/sync_test.go
+++ b/eks/sync_test.go
@@ -195,8 +195,9 @@ func TestFindLatestEKSBuild(t *testing.T) {
 		region          string
 		expectedVersion string
 	}{
-		{"1.20", "us-east-1", "1.20.4-eksbuild.2"},
-		{"1.22", "us-east-1", "1.22.6-eksbuild.1"},
+		{"1.20", "us-east-1", "1.20.15-eksbuild.2"},
+		{"1.22", "us-east-1", "1.22.11-eksbuild.2"},
+		{"1.23", "us-east-1", "1.23.7-minimal-eksbuild.1"},
 	}
 
 	for _, tc := range testCase {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #171 

This PR updates the `eks sync-core-components` command to add support for k8s version 1.23. This also removes support for 1.19, which [has reached end of support in EKS](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar).

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
