### PR TITLE
feature/k8s 125

### DIFF
--- a/eks/sync.go
+++ b/eks/sync.go
@@ -39,30 +39,30 @@ const (
 
 var (
 	// NOTE: Ensure that there is an entry for each supported version in the following tables.
-	supportedVersions = []string{"1.24", "1.23", "1.22", "1.21"}
+	supportedVersions = []string{"1.25", "1.24", "1.23", "1.22"}
 
 	// Reference: https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html
 	coreDNSVersionLookupTable = map[string]string{
+		"1.25": "1.9.3-eksbuild",
 		"1.24": "1.8.7-eksbuild",
 		"1.23": "1.8.7-eksbuild",
 		"1.22": "1.8.7",
-		"1.21": "1.8.4",
 	}
 
 	// Reference: https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html#updating-kube-proxy-add-on
 	kubeProxyVersionLookupTable = map[string]string{
+		"1.25": "1.25.6-minimal-eksbuild",
 		"1.24": "1.24.7-minimal-eksbuild",
 		"1.23": "1.23.8-minimal-eksbuild",
 		"1.22": "1.22.11-minimal-eksbuild",
-		"1.21": "1.21.14-minimal-eksbuild",
 	}
 
 	// Reference: https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html
 	amazonVPCCNIVersionLookupTable = map[string]string{
+		"1.25": "1.12.2",
 		"1.24": "1.11.4",
 		"1.23": "1.11.4",
 		"1.22": "1.11.4",
-		"1.21": "1.11.4",
 	}
 
 	defaultContainerImageAccount = "602401143452"
@@ -108,9 +108,9 @@ type componentVersions struct {
 // https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html
 // There are three core applications on an EKS cluster:
 //
-//    - kube-proxy
-//    - coredns
-//    - VPC CNI Plugin
+//   - kube-proxy
+//   - coredns
+//   - VPC CNI Plugin
 //
 // Each of these is managed in Kubernetes as DaemonSet, Deployment, and DaemonSet respectively. This command will use
 // the k8s API and kubectl command under the hood to patch the manifests to deploy the expected version based on what

--- a/eks/sync_test.go
+++ b/eks/sync_test.go
@@ -197,11 +197,11 @@ func TestFindLatestEKSBuilds(t *testing.T) {
 		region          string
 		expectedVersion string
 	}{
-		{coreDNSVersionLookupTable, coreDNSRepoPath, "1.25", "us-east-1", "v1.9.3-eksbuild.2"},
-		{coreDNSVersionLookupTable, coreDNSRepoPath, "1.24", "us-east-1", "1.8.7-eksbuild.3"},
-		{coreDNSVersionLookupTable, coreDNSRepoPath, "1.23", "us-east-1", "1.8.7-eksbuild.3"},
+		{coreDNSVersionLookupTable, coreDNSRepoPath, "1.25", "us-east-1", "1.9.3-eksbuild.2"},
+		{coreDNSVersionLookupTable, coreDNSRepoPath, "1.24", "us-east-1", "1.8.7-eksbuild.4"},
+		{coreDNSVersionLookupTable, coreDNSRepoPath, "1.23", "us-east-1", "1.8.7-eksbuild.4"},
 		{coreDNSVersionLookupTable, coreDNSRepoPath, "1.22", "us-east-1", "1.8.7"},
-		{kubeProxyVersionLookupTable, kubeProxyRepoPath, "1.25", "us-east-1", "v1.25.6-minimal-eksbuild.1"},
+		{kubeProxyVersionLookupTable, kubeProxyRepoPath, "1.25", "us-east-1", "1.25.6-minimal-eksbuild.1"},
 		{kubeProxyVersionLookupTable, kubeProxyRepoPath, "1.24", "us-east-1", "1.24.7-minimal-eksbuild.2"},
 		{kubeProxyVersionLookupTable, kubeProxyRepoPath, "1.23", "us-east-1", "1.23.8-minimal-eksbuild.2"},
 		{kubeProxyVersionLookupTable, kubeProxyRepoPath, "1.22", "us-east-1", "1.22.11-minimal-eksbuild.2"},

--- a/eks/sync_test.go
+++ b/eks/sync_test.go
@@ -197,9 +197,11 @@ func TestFindLatestEKSBuilds(t *testing.T) {
 		region          string
 		expectedVersion string
 	}{
+		{coreDNSVersionLookupTable, coreDNSRepoPath, "1.25", "us-east-1", "v1.9.3-eksbuild.2"},
 		{coreDNSVersionLookupTable, coreDNSRepoPath, "1.24", "us-east-1", "1.8.7-eksbuild.3"},
 		{coreDNSVersionLookupTable, coreDNSRepoPath, "1.23", "us-east-1", "1.8.7-eksbuild.3"},
 		{coreDNSVersionLookupTable, coreDNSRepoPath, "1.22", "us-east-1", "1.8.7"},
+		{kubeProxyVersionLookupTable, kubeProxyRepoPath, "1.25", "us-east-1", "v1.25.6-minimal-eksbuild.1"},
 		{kubeProxyVersionLookupTable, kubeProxyRepoPath, "1.24", "us-east-1", "1.24.7-minimal-eksbuild.2"},
 		{kubeProxyVersionLookupTable, kubeProxyRepoPath, "1.23", "us-east-1", "1.23.8-minimal-eksbuild.2"},
 		{kubeProxyVersionLookupTable, kubeProxyRepoPath, "1.22", "us-east-1", "1.22.11-minimal-eksbuild.2"},


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #184 .

This PR updates the eks sync-core-components command to add support for k8s version 1.25. This also removes support for 1.21 which [has reached end of support in EKS](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar).

passing tests: https://app.circleci.com/pipelines/github/gruntwork-io/kubergrunt/640/workflows/04ee4979-38e9-4202-8875-fd3a0f145d2e/jobs/1129

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].
[x] Added support for k8s v1.25 
[x] Removed EOL v1.21

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
