### PR TITLE
add eks 1.27 and remove 1.22

### DIFF
--- a/eks/sync.go
+++ b/eks/sync.go
@@ -39,33 +39,33 @@ const (
 
 var (
 	// NOTE: Ensure that there is an entry for each supported version in the following tables.
-	supportedVersions = []string{"1.26", "1.25", "1.24", "1.23", "1.22"}
+	supportedVersions = []string{"1.27", "1.26", "1.25", "1.24", "1.23"}
 
 	// Reference: https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html
 	coreDNSVersionLookupTable = map[string]string{
+		"1.27": "1.10.1-eksbuild",
 		"1.26": "1.9.3-eksbuild",
 		"1.25": "1.9.3-eksbuild",
 		"1.24": "1.8.7-eksbuild",
 		"1.23": "1.8.7-eksbuild",
-		"1.22": "1.8.7",
 	}
 
 	// Reference: https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html#updating-kube-proxy-add-on
 	kubeProxyVersionLookupTable = map[string]string{
+		"1.27": "1.27.1-minimal-eksbuild",
 		"1.26": "1.26.2-minimal-eksbuild",
 		"1.25": "1.25.6-minimal-eksbuild",
 		"1.24": "1.24.7-minimal-eksbuild",
 		"1.23": "1.23.8-minimal-eksbuild",
-		"1.22": "1.22.11-minimal-eksbuild",
 	}
 
 	// Reference: https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html
 	amazonVPCCNIVersionLookupTable = map[string]string{
+		"1.27": "1.13.2",
 		"1.26": "1.12.6",
 		"1.25": "1.12.2",
 		"1.24": "1.11.4",
 		"1.23": "1.11.4",
-		"1.22": "1.11.4",
 	}
 
 	defaultContainerImageAccount = "602401143452"

--- a/eks/sync_test.go
+++ b/eks/sync_test.go
@@ -197,16 +197,16 @@ func TestFindLatestEKSBuilds(t *testing.T) {
 		region          string
 		expectedVersion string
 	}{
+		{coreDNSVersionLookupTable, coreDNSRepoPath, "1.27", "us-east-1", "1.10.1-eksbuild.2"},
 		{coreDNSVersionLookupTable, coreDNSRepoPath, "1.26", "us-east-1", "1.9.3-eksbuild.5"},
 		{coreDNSVersionLookupTable, coreDNSRepoPath, "1.25", "us-east-1", "1.9.3-eksbuild.5"},
 		{coreDNSVersionLookupTable, coreDNSRepoPath, "1.24", "us-east-1", "1.8.7-eksbuild.7"},
 		{coreDNSVersionLookupTable, coreDNSRepoPath, "1.23", "us-east-1", "1.8.7-eksbuild.7"},
-		{coreDNSVersionLookupTable, coreDNSRepoPath, "1.22", "us-east-1", "1.8.7"},
+		{kubeProxyVersionLookupTable, kubeProxyRepoPath, "1.27", "us-east-1", "1.27.1-minimal-eksbuild.1"},
 		{kubeProxyVersionLookupTable, kubeProxyRepoPath, "1.26", "us-east-1", "1.26.2-minimal-eksbuild.1"},
 		{kubeProxyVersionLookupTable, kubeProxyRepoPath, "1.25", "us-east-1", "1.25.6-minimal-eksbuild.2"},
 		{kubeProxyVersionLookupTable, kubeProxyRepoPath, "1.24", "us-east-1", "1.24.7-minimal-eksbuild.2"},
 		{kubeProxyVersionLookupTable, kubeProxyRepoPath, "1.23", "us-east-1", "1.23.8-minimal-eksbuild.2"},
-		{kubeProxyVersionLookupTable, kubeProxyRepoPath, "1.22", "us-east-1", "1.22.11-minimal-eksbuild.2"},
 	}
 
 	for _, tc := range testCase {


### PR DESCRIPTION
<!--
Have any questions? Check out the contributing docs at https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e,
or ask in this Pull Request and a Gruntwork core maintainer will be happy to help :)
Note: Remember to add '[WIP]' to the beginning of the title if this PR is still a work-in-progress. Remove it when it is ready for review!
-->

## Description

Fixes #201 .

### Documentation

<!--
  If this is a feature PR, then where is it documented?

  - If docs exist:
    - Update any references, if relevant.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->


## TODOs
Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).
<!-- Description of the changes introduced by this PR. -->


Please ensure all of these TODOs are completed before asking for a review.

- [x] Ensure the branch is named correctly with the issue number. e.g: `feature/new-vpc-endpoints-955` or `bug/missing-count-param-434`.
- [x] Update the docs.
- [x] Keep the changes backward compatible where possible.
- [x] Run the pre-commit checks successfully.
- [x] Run the relevant tests successfully.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.

## Release Notes (draft)

<!--
  Link to related issues, and issues fixed or partially addressed by this PR.
  e.g. Fixes #1234
  e.g. Addresses #1234
  e.g. Related to #1234
-->

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].
[x] Added support for k8s v1.27
[x] Removed EOL k8s v1.22

### Migration Guide
Kubergrunt v0.12 and above work with EKS v1.23 and higher. 
AWS has dropped support for EKS v1.22. If you need to continue working with that version, please use Kubergrunt v0.11.3 
<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->