### PR TITLE
🐛 (eks sync-core-components): Increase maxEKSBuild

### DIFF
--- a/eks/sync.go
+++ b/eks/sync.go
@@ -34,7 +34,7 @@ const (
 	coreDNSRepoPath   = "eks/coredns"
 
 	// Largest eksbuild tag we will try looking for.
-	maxEKSBuild = 10
+	maxEKSBuild = 20
 )
 
 var (


### PR DESCRIPTION
## Description

Fixes #214

The maximum number of builds (sub-patches?) to search for with eks compnent images was hard coded to 10 (actually 9, since the last one has to error / miss for the code to work), but there are in fact 10 builds of eks/coredns:1.9.3-eksbuild. This doubles the threshold to 20, to reduce the chances of this happening again.

At present any attempt to create / update an EKS cluster using K8s 1.26 will error (see #214).

```shell
$ curl https://602401143452.dkr.ecr.us-west-2.amazonaws.com/v2/eks/coredns/manifests/v1.9.3-eksbuild.10 -H "Authorization: Basic $token"
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 739,
         "digest": "sha256:ccd971aef1b9e189ec21a2e70ba93ed6a339ea8be071f28cff6833db833fd742",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 739,
         "digest": "sha256:00905877cf1be0c1440cde988319f5a6fff848dd783a4517db3c848fd7ef9c5c",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      }
   ]
}
```

- [x] Ensure the branch is named correctly with the issue number. e.g: `feature/new-vpc-endpoints-955` or `bug/missing-count-param-434`.
~~- [ ] Update the docs.~~
- [x] Keep the changes backward compatible where possible.
- [ ] Run the pre-commit checks successfully.
~~- [ ] Run the relevant tests successfully.~~

## Release Notes

Increase maxEKSBuild to 20, Fixes #214 