### PR TITLE
Add Support for EKS 1.29

### DIFF
--- a/eks/sync.go
+++ b/eks/sync.go
@@ -43,11 +43,11 @@ var (
 
 	// Reference: https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html
 	coreDNSVersionLookupTable = map[string]string{
-		"1.29": "v1.11.1-eksbuild",
-		"1.28": "v1.10.1-eksbuild",
-		"1.27": "v1.10.1-eksbuild",
-		"1.26": "v1.9.3-eksbuild",
-		"1.25": "v1.9.3-eksbuild",
+		"1.29": "1.11.1-eksbuild",
+		"1.28": "1.10.1-eksbuild",
+		"1.27": "1.10.1-eksbuild",
+		"1.26": "1.9.3-eksbuild",
+		"1.25": "1.9.3-eksbuild",
 	}
 
 	// Reference: https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html#updating-kube-proxy-add-on

--- a/eks/sync.go
+++ b/eks/sync.go
@@ -39,33 +39,33 @@ const (
 
 var (
 	// NOTE: Ensure that there is an entry for each supported version in the following tables.
-	supportedVersions = []string{"1.28", "1.27", "1.26", "1.25", "1.24"}
+	supportedVersions = []string{"1.29", "1.28", "1.27", "1.26", "1.25"}
 
 	// Reference: https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html
 	coreDNSVersionLookupTable = map[string]string{
-		"1.28": "1.10.1-eksbuild",
-		"1.27": "1.10.1-eksbuild",
-		"1.26": "1.9.3-eksbuild",
-		"1.25": "1.9.3-eksbuild",
-		"1.24": "1.9.3-eksbuild",
+		"1.29": "v1.11.1-eksbuild",
+		"1.28": "v1.10.1-eksbuild",
+		"1.27": "v1.10.1-eksbuild",
+		"1.26": "v1.9.3-eksbuild",
+		"1.25": "v1.9.3-eksbuild",
 	}
 
 	// Reference: https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html#updating-kube-proxy-add-on
 	kubeProxyVersionLookupTable = map[string]string{
-		"1.28": "1.28.2-minimal-eksbuild",
-		"1.27": "1.27.6-minimal-eksbuild",
-		"1.26": "1.26.9-minimal-eksbuild",
-		"1.25": "1.25.14-minimal-eksbuild",
-		"1.24": "1.24.17-minimal-eksbuild",
+		"1.29": "1.29.1-minimal-eksbuild",
+		"1.28": "1.28.6-minimal-eksbuild",
+		"1.27": "1.27.10-minimal-eksbuild",
+		"1.26": "1.26.13-minimal-eksbuild",
+		"1.25": "1.25.16-minimal-eksbuild",
 	}
 
 	// Reference: https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html
 	amazonVPCCNIVersionLookupTable = map[string]string{
-		"1.28": "1.15.1",
-		"1.27": "1.15.1",
-		"1.26": "1.15.1",
-		"1.25": "1.15.1",
-		"1.24": "1.15.1",
+		"1.29": "1.16.2",
+		"1.28": "1.16.2",
+		"1.27": "1.16.2",
+		"1.26": "1.16.2",
+		"1.25": "1.16.2",
 	}
 
 	defaultContainerImageAccount = "602401143452"

--- a/eks/sync_test.go
+++ b/eks/sync_test.go
@@ -198,15 +198,15 @@ func TestFindLatestEKSBuilds(t *testing.T) {
 		expectedVersion string
 	}{
 		{coreDNSVersionLookupTable, coreDNSRepoPath, "1.29", "us-east-1", "1.11.1-eksbuild.6"},
-		{coreDNSVersionLookupTable, coreDNSRepoPath, "1.28", "us-east-1", "1.10.1-eksbuild.7"},
-		{coreDNSVersionLookupTable, coreDNSRepoPath, "1.27", "us-east-1", "1.10.1-eksbuild.7"},
-		{coreDNSVersionLookupTable, coreDNSRepoPath, "1.26", "us-east-1", "1.9.3-eksbuild.11"},
-		{coreDNSVersionLookupTable, coreDNSRepoPath, "1.25", "us-east-1", "1.9.3-eksbuild.11"},
-		{kubeProxyVersionLookupTable, kubeProxyRepoPath, "1.29", "us-east-1", "1.29.1-minimal-eksbuild.2"},
-		{kubeProxyVersionLookupTable, kubeProxyRepoPath, "1.28", "us-east-1", "1.28.6-minimal-eksbuild.2"},
-		{kubeProxyVersionLookupTable, kubeProxyRepoPath, "1.27", "us-east-1", "1.27.10-minimal-eksbuild.2"},
-		{kubeProxyVersionLookupTable, kubeProxyRepoPath, "1.26", "us-east-1", "1.26.13-minimal-eksbuild.2"},
-		{kubeProxyVersionLookupTable, kubeProxyRepoPath, "1.25", "us-east-1", "1.25.16-minimal-eksbuild.3"},
+		{coreDNSVersionLookupTable, coreDNSRepoPath, "1.28", "us-east-1", "1.10.1-eksbuild.8"},
+		{coreDNSVersionLookupTable, coreDNSRepoPath, "1.27", "us-east-1", "1.10.1-eksbuild.8"},
+		{coreDNSVersionLookupTable, coreDNSRepoPath, "1.26", "us-east-1", "1.9.3-eksbuild.12"},
+		{coreDNSVersionLookupTable, coreDNSRepoPath, "1.25", "us-east-1", "1.9.3-eksbuild.12"},
+		{kubeProxyVersionLookupTable, kubeProxyRepoPath, "1.29", "us-east-1", "1.29.1-minimal-eksbuild.3"},
+		{kubeProxyVersionLookupTable, kubeProxyRepoPath, "1.28", "us-east-1", "1.28.6-minimal-eksbuild.3"},
+		{kubeProxyVersionLookupTable, kubeProxyRepoPath, "1.27", "us-east-1", "1.27.10-minimal-eksbuild.3"},
+		{kubeProxyVersionLookupTable, kubeProxyRepoPath, "1.26", "us-east-1", "1.26.13-minimal-eksbuild.3"},
+		{kubeProxyVersionLookupTable, kubeProxyRepoPath, "1.25", "us-east-1", "1.25.16-minimal-eksbuild.4"},
 	}
 
 	for _, tc := range testCase {

--- a/eks/sync_test.go
+++ b/eks/sync_test.go
@@ -197,16 +197,16 @@ func TestFindLatestEKSBuilds(t *testing.T) {
 		region          string
 		expectedVersion string
 	}{
-		{coreDNSVersionLookupTable, coreDNSRepoPath, "1.28", "us-east-1", "1.10.1-eksbuild.8"},
-		{coreDNSVersionLookupTable, coreDNSRepoPath, "1.27", "us-east-1", "1.10.1-eksbuild.8"},
-		{coreDNSVersionLookupTable, coreDNSRepoPath, "1.26", "us-east-1", "1.9.3-eksbuild.12"},
-		{coreDNSVersionLookupTable, coreDNSRepoPath, "1.25", "us-east-1", "1.9.3-eksbuild.12"},
-		{coreDNSVersionLookupTable, coreDNSRepoPath, "1.24", "us-east-1", "1.9.3-eksbuild.12"},
-		{kubeProxyVersionLookupTable, kubeProxyRepoPath, "1.28", "us-east-1", "1.28.2-minimal-eksbuild.2"},
-		{kubeProxyVersionLookupTable, kubeProxyRepoPath, "1.27", "us-east-1", "1.27.6-minimal-eksbuild.2"},
-		{kubeProxyVersionLookupTable, kubeProxyRepoPath, "1.26", "us-east-1", "1.26.9-minimal-eksbuild.2"},
-		{kubeProxyVersionLookupTable, kubeProxyRepoPath, "1.25", "us-east-1", "1.25.14-minimal-eksbuild.2"},
-		{kubeProxyVersionLookupTable, kubeProxyRepoPath, "1.24", "us-east-1", "1.24.17-minimal-eksbuild.8"},
+		{coreDNSVersionLookupTable, coreDNSRepoPath, "1.29", "us-east-1", "1.11.1-eksbuild.6"},
+		{coreDNSVersionLookupTable, coreDNSRepoPath, "1.28", "us-east-1", "1.10.1-eksbuild.7"},
+		{coreDNSVersionLookupTable, coreDNSRepoPath, "1.27", "us-east-1", "1.10.1-eksbuild.7"},
+		{coreDNSVersionLookupTable, coreDNSRepoPath, "1.26", "us-east-1", "1.9.3-eksbuild.11"},
+		{coreDNSVersionLookupTable, coreDNSRepoPath, "1.25", "us-east-1", "1.9.3-eksbuild.11"},
+		{kubeProxyVersionLookupTable, kubeProxyRepoPath, "1.29", "us-east-1", "1.29.1-minimal-eksbuild.2"},
+		{kubeProxyVersionLookupTable, kubeProxyRepoPath, "1.28", "us-east-1", "1.28.6-minimal-eksbuild.2"},
+		{kubeProxyVersionLookupTable, kubeProxyRepoPath, "1.27", "us-east-1", "1.27.10-minimal-eksbuild.2"},
+		{kubeProxyVersionLookupTable, kubeProxyRepoPath, "1.26", "us-east-1", "1.26.13-minimal-eksbuild.2"},
+		{kubeProxyVersionLookupTable, kubeProxyRepoPath, "1.25", "us-east-1", "1.25.16-minimal-eksbuild.3"},
 	}
 
 	for _, tc := range testCase {


### PR DESCRIPTION
<!--
Have any questions? Check out the contributing docs at https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e,
or ask in this Pull Request and a Gruntwork core maintainer will be happy to help :)
Note: Remember to add '[WIP]' to the beginning of the title if this PR is still a work-in-progress. Remove it when it is ready for review!
-->

## Description

Fixes #226 

This PR adds support for EKS 1.29 and drops support for EKS 1.24.

### Documentation

<!--
  If this is a feature PR, then where is it documented?

  - If docs exist:
    - Update any references, if relevant.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->


## TODOs
Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).
<!-- Description of the changes introduced by this PR. -->


Please ensure all of these TODOs are completed before asking for a review.

- [ ] Ensure the branch is named correctly with the issue number. e.g: `feature/new-vpc-endpoints-955` or `bug/missing-count-param-434`.
- [ ] Update the docs.
- [ ] Keep the changes backward compatible where possible.
- [ ] Run the pre-commit checks successfully.
- [ ] Run the relevant tests successfully.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.

## Release Notes (draft)

<!--
  Link to related issues, and issues fixed or partially addressed by this PR.
  e.g. Fixes #1234
  e.g. Addresses #1234
  e.g. Related to #1234
-->

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->